### PR TITLE
Bug fix for variable localization in the LETKF

### DIFF
--- a/src/Applications/UMD_Etc/UMD_oletkf/letkf_tools.f90
+++ b/src/Applications/UMD_Etc/UMD_oletkf/letkf_tools.f90
@@ -430,10 +430,10 @@ SUBROUTINE das_letkf(gues3d,gues2d,anal3d,anal2d)
       !-------------------------------------------------------------------------
       if (ilev == 1) then !update 2d variable at ilev=1
         do n=1,nv2d
-          if (var_local_n2n(nv3d+n) <= nv3d) then
+          if (var_local_n2n(nv3d+n) <= nv3d) then ! pattern found from previous 3d var
             trans(:,:,nv3d+n) = trans(:,:,var_local_n2n(nv3d+n))
-            work2d(ij,n) = work2d(ij,var_local_n2n(nv3d+n))
-          elseif (var_local_n2n(nv3d+n) < nv3d+n) then
+            work2d(ij,n) = work3d(ij,ilev,var_local_n2n(nv3d+n))
+          elseif (var_local_n2n(nv3d+n) < nv3d+n) then ! pattern found from previous 2d var
             trans(:,:,nv3d+n) = trans(:,:,var_local_n2n(nv3d+n))
             work2d(ij,n) = work2d(ij,var_local_n2n(nv3d+n)-nv3d)
           else


### PR DESCRIPTION
## Brief description
This PR fixes the bug in the variable localization in the LETKF.

LETKF updates allow selecting a different subset of observation types to update model variables (e.g., only enable temperature obs to improve temperature, but not salinity). When the variable localization is used, even at one model grid, we need to calculate LETKF weights several times due to different observation selection rules for each variable.

To accelerate calculation, we first check if the same observation selection rule has been applied to the calculated model states. If found, we copy LETKF weights from that variable directly.

Under this "if” condition, work2d should copy LETKF weights & inflation parameters from the previous 3d variable at the model surface instead of the 2d variable.

##  Impact of this bug to the S2S-3 running:
**The current S2S-3 setting does not trigger this bug** because of two parameters:
1. `letkf_local.f90: Line 58: REAL(r_size),PARAMETER :: var_local(nv3d+nv2d,nid_obs) = 1.0d0`
    Which says to use all observation types to update every model state

2. In the LETKF input namelist (`input_*.nml`): 
```
&params_letkf_nml
 cov_infl_mul = 1.0d0, 
```
Which says use no inflation

The consequence is that work2d(ij,n) is always equal to work2d(ij,1) = 1.0d0.



## Features added
N/A

## Bugs fixed
N/A

## Test changes
None

## Documentation changes
None

## Does this create a breaking change?
No



