### PR TITLE
add back the missing connectivity in OGCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Fixed a missing link(connectivity) in OGCM causing spurious FRAZIL ice production in S2S3 ODAS. 
+
 ### Added
 
 - The new DataAtm has been backported from the current GEOS version to the S2Sv3 model, it replaced the old one. It includes the atmospheric component of OASIM (Ocean and Atmosphere Spectral Irradiance Model) that is used to force OBIO (NOBM).

--- a/src/GEOSgcs_GridComp/GEOSgcm_GridComp/GEOSogcm_GridComp/GEOS_OgcmGridComp.F90
+++ b/src/GEOSgcs_GridComp/GEOSgcm_GridComp/GEOSogcm_GridComp/GEOS_OgcmGridComp.F90
@@ -716,6 +716,13 @@ contains
      VERIFY_(STATUS)
   end if
 
+  call MAPL_AddConnectivity ( GC,  &
+          SHORT_NAME  = (/'FRACICE'/), &
+          DST_ID = OCEAN,             &
+          SRC_ID = SEAICE,            &
+          RC=STATUS  )
+  VERIFY_(STATUS)
+
   if(DUAL_OCEAN) then 
      call MAPL_AddConnectivity ( GC,  &
           SRC_NAME  = (/'FRACICE'/), & 


### PR DESCRIPTION
This PR fixed a missing connectivity between OCEAN and SEAICE in OGCM gridcomp. The connectivity is critical to running coupled model in DUAL_OCEAN mode.