### PR TITLE
Fixes for S2S scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
+
 - Fixed a missing link(connectivity) in OGCM causing spurious FRAZIL ice production in S2S3 ODAS. 
+- Fixed issue with `gcm_setup` not templating `input.nml` correctly for all coupled cases
 
 ### Added
 
@@ -17,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 -- Added fix for uninitialized per-grid counters in the coupler, brought hash.c from MAPL v2.51.1 to fix minor bugs
-	
 - In the coupled run the GOCART AERO_DP bundle consists of 20 groups of aerosols. When the model is coupled to DataAtm and OBIO, a corresponding AERO_DP bundle is created in DataAtm GC that consists only the 5 groups of aerosols that OBIO needs. For this reason, the way Surf GC handles the AERO_DP bundle has been modified to accommodate the two possible sources of the bundle. Previously, Surf GC expected all the 20 groups of GOCART aerosols to be present in the AERO_DP bundle, but now it has been tailored to processes any number out of the 20 groups that exist in the AERO_DP bundle.
 - Updated `gcm_setup` with a question for data atmosphere in coupled runs
 

--- a/src/Applications/GEOSgcm_App/field_table_GEOSS2S3.tmpl
+++ b/src/Applications/GEOSgcm_App/field_table_GEOSS2S3.tmpl
@@ -1,0 +1,210 @@
+"prog_tracers","ocean_mod","temp"
+horizontal-advection-scheme = mdppm
+vertical-advection-scheme = mdppm
+restart_file  = ocean_temp_salt.res.nc
+ppm_hlimiter = 3
+ppm_vlimiter = 3
+/
+"prog_tracers","ocean_mod","salt"
+horizontal-advection-scheme = mdppm
+vertical-advection-scheme = mdppm
+restart_file  = ocean_temp_salt.res.nc
+ppm_hlimiter = 3
+ppm_vlimiter = 3
+/
+"tracer_packages","ocean_mod","ocean_age_tracer"
+names = global
+const_init_tracer=.true.
+horizontal-advection-scheme = mdppm
+vertical-advection-scheme = mdppm
+ppm_hlimiter = 3
+ppm_vlimiter = 3
+restart_file = ocean_age.res.nc
+min_tracer_limit=0.0
+/
+"namelists","ocean_mod","ocean_age_tracer/global"
+slat = -90.0
+nlat =  90.0
+wlon =   0.0
+elon = 360.0
+/
+
+"rayleigh_damp_table","ocean_mod","rayleigh_damp_table"
+"rayleigh_damp_table","torres_001","itable=250,jtable=455,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","torres_002","itable=250,jtable=456,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","torres_003","itable=250,jtable=457,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","torres_004","itable=250,jtable=458,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","torres_005","itable=250,jtable=459,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","torres_006","itable=250,jtable=460,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","torres_007","itable=249,jtable=455,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_008","itable=249,jtable=456,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_009","itable=249,jtable=457,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_010","itable=249,jtable=458,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_011","itable=249,jtable=459,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_012","itable=249,jtable=460,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_013","itable=251,jtable=455,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_014","itable=251,jtable=456,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_015","itable=251,jtable=457,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_016","itable=251,jtable=458,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_017","itable=251,jtable=459,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_018","itable=251,jtable=460,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","torres_019","itable=248,jtable=452,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_021","itable=248,jtable=453,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_022","itable=248,jtable=454,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_023","itable=248,jtable=455,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_024","itable=248,jtable=456,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_025","itable=248,jtable=457,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_026","itable=248,jtable=458,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_027","itable=248,jtable=459,ktable_1=1,ktable_2=6,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_028","itable=248,jtable=460,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_029","itable=252,jtable=451,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_030","itable=252,jtable=452,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_031","itable=252,jtable=453,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_032","itable=252,jtable=454,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_033","itable=252,jtable=455,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_034","itable=252,jtable=456,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_035","itable=252,jtable=457,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_036","itable=252,jtable=458,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_037","itable=252,jtable=459,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_038","itable=252,jtable=460,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","torres_039","itable=247,jtable=453,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_040","itable=247,jtable=454,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_041","itable=247,jtable=455,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_042","itable=247,jtable=456,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_043","itable=247,jtable=457,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_044","itable=247,jtable=458,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_045","itable=247,jtable=459,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_046","itable=247,jtable=460,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_047","itable=253,jtable=449,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_048","itable=253,jtable=450,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_049","itable=253,jtable=451,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_050","itable=253,jtable=452,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_051","itable=253,jtable=453,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_052","itable=253,jtable=454,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_053","itable=253,jtable=455,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_054","itable=253,jtable=456,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_055","itable=253,jtable=457,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_056","itable=253,jtable=458,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_057","itable=253,jtable=459,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_058","itable=253,jtable=460,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","torres_059","itable=253,jtable=461,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","malacca_001","itable=91,jtable=503,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","malacca_002","itable=91,jtable=504,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","malacca_003","itable=91,jtable=505,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","malacca_004","itable=96,jtable=498,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","malacca_005","itable=97,jtable=498,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","malacca_006","itable=98,jtable=498,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","malacca_007","itable=98,jtable=499,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","malacca_008","itable=98,jtable=500,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","malacca_009","itable=98,jtable=501,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","malacca_010","itable=92,jtable=502,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","malacca_011","itable=92,jtable=503,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","malacca_012","itable=92,jtable=504,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","malacca_013","itable=96,jtable=499,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","malacca_014","itable=97,jtable=499,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","malacca_015","itable=97,jtable=500,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","malacca_016","itable=97,jtable=501,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","malacca_017","itable=93,jtable=502,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","malacca_018","itable=93,jtable=503,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","malacca_019","itable=93,jtable=504,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","malacca_020","itable=95,jtable=500,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","malacca_021","itable=96,jtable=500,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","malacca_022","itable=96,jtable=501,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","malacca_023","itable=96,jtable=502,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","malacca_024","itable=96,jtable=503,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","malacca_025","itable=94,jtable=501,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","malacca_026","itable=95,jtable=501,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","malacca_027","itable=94,jtable=502,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","malacca_028","itable=95,jtable=502,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","malacca_029","itable=94,jtable=503,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","malacca_030","itable=95,jtable=503,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","karimat_001","itable=106,jtable=484,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_002","itable=106,jtable=485,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_003","itable=107,jtable=484,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_004","itable=107,jtable=485,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_005","itable=107,jtable=486,ktable_1=1,ktable_2=5,rayleigh_damp_table=2700.0"
+"rayleigh_damp_table","karimat_006","itable=108,jtable=484,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_007","itable=108,jtable=485,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_008","itable=108,jtable=486,ktable_1=1,ktable_2=5,rayleigh_damp_table=2700.0"
+"rayleigh_damp_table","karimat_009","itable=108,jtable=487,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_010","itable=108,jtable=488,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_011","itable=109,jtable=484,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_012","itable=109,jtable=485,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_013","itable=109,jtable=486,ktable_1=1,ktable_2=5,rayleigh_damp_table=2700.0"
+"rayleigh_damp_table","karimat_014","itable=109,jtable=487,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_015","itable=109,jtable=488,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_016","itable=110,jtable=484,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_017","itable=110,jtable=485,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_018","itable=110,jtable=486,ktable_1=1,ktable_2=5,rayleigh_damp_table=2700.0"
+"rayleigh_damp_table","karimat_019","itable=110,jtable=487,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_020","itable=110,jtable=488,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_021","itable=111,jtable=484,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_022","itable=111,jtable=488,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_023","itable=112,jtable=484,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_024","itable=112,jtable=488,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_025","itable=113,jtable=484,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_026","itable=113,jtable=488,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_027","itable=114,jtable=484,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_028","itable=114,jtable=485,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_029","itable=114,jtable=486,ktable_1=1,ktable_2=5,rayleigh_damp_table=2700.0"
+"rayleigh_damp_table","karimat_030","itable=114,jtable=487,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_031","itable=114,jtable=488,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_032","itable=115,jtable=485,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_033","itable=115,jtable=486,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","karimat_034","itable=115,jtable=487,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","karimat_035","itable=116,jtable=486,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","sunda_001","itable=101,jtable=473,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","sunda_002","itable=101,jtable=474,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","sunda_003","itable=102,jtable=473,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","sunda_004","itable=102,jtable=474,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","sunda_005","itable=103,jtable=474,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","sunda_006","itable=104,jtable=474,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","sunda_007","itable=104,jtable=475,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","sunda_008","itable=104,jtable=476,ktable_1=1,ktable_2=6,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","sunda_009","itable=104,jtable=477,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","sunda_010","itable=104,jtable=478,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","sunda_011","itable=105,jtable=474,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","sunda_012","itable=105,jtable=475,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","sunda_013","itable=105,jtable=476,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","sunda_014","itable=105,jtable=477,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","sunda_015","itable=106,jtable=474,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","sunda_016","itable=106,jtable=475,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","sunda_017","itable=106,jtable=476,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","sunda_018","itable=107,jtable=474,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","sunda_019","itable=107,jtable=475,ktable_1=1,ktable_2=5,rayleigh_damp_table=10800.0"
+"rayleigh_damp_table","sape_001","itable=157,jtable=462,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","sape_001","itable=157,jtable=463,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","sape_002","itable=157,jtable=464,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","sape_004","itable=158,jtable=464,ktable_1=1,ktable_2=5,rayleigh_damp_table=1800.0"
+"rayleigh_damp_table","sanberd_001","itable=175,jtable=549,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","sanberd_002","itable=176,jtable=548,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","sanberd_003","itable=176,jtable=549,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","sanberd_004","itable=177,jtable=549,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","sanberd_005","itable=177,jtable=550,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","sanberd_006","itable=178,jtable=549,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","surigao_001","itable=181,jtable=538,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","surigao_002","itable=182,jtable=538,ktable_1=1,ktable_2=5,rayleigh_damp_table=3600.0"
+"rayleigh_damp_table","surigao_003","itable=182,jtable=539,ktable_1=1,ktable_2=5,rayleigh_damp_table=5400.0"
+"rayleigh_damp_table","surigao_004","itable=182,jtable=540,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","surigao_005","itable=183,jtable=538,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","surigao_006","itable=183,jtable=539,ktable_1=1,ktable_2=5,rayleigh_damp_table=7200.0"
+"rayleigh_damp_table","surigao_007","itable=183,jtable=540,ktable_1=1,ktable_2=5,rayleigh_damp_table=9000.0"
+"rayleigh_damp_table","gibraltar_001","itable=1097,jtable=652,ktable_1=1,ktable_2=20,rayleigh_damp_table=7200.0"/
+
+
+#"riverspread","ocean_mod","riverspread"
+#"riverspread", "Uruguay", "iloc=887,jloc=349,is=887,ie=890,js=348,je=351"/
+
+#
+#"tracer_packages","ocean_mod","generic_gen"
+#const_init_tracer = .true.
+#restart_file = generic_gen_res.nc
+#horizontal-advection-scheme = upwind
+#vertical-advection-scheme = upwind
+#ppm_hlimiter=2
+#ppm_vlimiter=2
+#/
+#
+#"namelists", "ocean_mod", "generic_gen"
+#
+#/

--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -78,7 +78,7 @@ end
 #######################################################################
 
 # Set default behavior of switches
-set NOCVS = FALSE
+set NOCVS = TRUE
 set GPU   = FALSE
 
 while ( $#argv > 0 )

--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -979,6 +979,7 @@ set USE_OCEANOBIOGEOCHEM = 0
 set DATA_ATMOS = FALSE 
 set ACTUAL_ATM4OCN = ""
 set USE_DATA_ATM4OCN = 0
+set RUN_DUAL = false
 
 if( $OGCM == "TRUE" ) then
 
@@ -1068,6 +1069,7 @@ RDUALOCEAN:
 
    if( $RDOCEAN == TRUE ) then
       set COUPLED_DUAL = ""
+      set RUN_DUAL = true
 
 AODAS:
       echo "       Do you wish to run the ${C1}AODAS${CN} Model? (Default: ${C2}NO${CN} or ${C2}FALSE${CN})"
@@ -2214,6 +2216,8 @@ s?@USE_OCEANOBIOGEOCHEM?$USE_OCEANOBIOGEOCHEM?g
 
 s?@ACTUAL_ATM4OCN?$ACTUAL_ATM4OCN?g
 s?@USE_DATA_ATM4OCN?$USE_DATA_ATM4OCN?g
+
+s?@RUN_DUAL?$RUN_DUAL?g
 
 
 EOF

--- a/src/Applications/GEOSgcm_App/input.nml.tmpl
+++ b/src/Applications/GEOSgcm_App/input.nml.tmpl
@@ -188,7 +188,7 @@
 /
 
  &ocean_increment_tracer_nml
-        use_this_module=.TRUE.
+        use_this_module=.@RUN_DUAL.
         days_to_increment = 0
         secs_to_increment = 64800
 /
@@ -373,9 +373,9 @@
       read_restore_mask=.false.
       restore_mask_gfdl=.false.
       max_ice_thickness=1.0
-      zero_net_water_restore=.true.
-      zero_net_water_coupler=.true.
-      zero_net_water_couple_restore=.true.
+      zero_net_water_restore=.@RUN_DUAL.
+      zero_net_water_coupler=.@RUN_DUAL.
+      zero_net_water_couple_restore=.@RUN_DUAL.
       zero_net_salt_restore=.false.
       avg_sfc_velocity=.false.
       avg_sfc_temp_salt_eta=.false.
@@ -437,8 +437,8 @@
 /
 
  &ocean_sponges_tracer_nml
-	use_this_module = .true.
-	damp_coeff_3d = .true.
+	use_this_module = .@RUN_DUAL.
+	damp_coeff_3d = .@RUN_DUAL.
 /
 
  &ocean_sponges_velocity_nml


### PR DESCRIPTION
As requested by @amolod, we add templating for a `.true.`/`.false.` for settings in `input.nml` that are different between running with dual-ocean and running without. The "without" now better matches the `input_GEOSS2S3.nml.tmpl` file used by Kazumi.

I also set `NOCVS` to `TRUE` by default, since, well, we aren't using CVS. I can remove the code later if desired.

@amolod Can you try this out and test it? It's possible there's a setting I missed somewhere. Also, this currently treats DualOcean_YES-ODAS_YES as the same as DualOcean_YES-ODAS_NO. If there are settings in `input.nml` that should be different between the two cases, let me know. 