### PR TITLE
Adding ARGO no file bomb, and obs file age checks

### DIFF
--- a/src/Applications/UMD_Etc/UMD_utils/ocean_obs.py
+++ b/src/Applications/UMD_Etc/UMD_utils/ocean_obs.py
@@ -1296,11 +1296,11 @@ if list_of_obs:
 
 #   check to make sure minimum observation types are in gmao- file
 #   instrument check (i.e. ARGO) follows below
-#   ominreq=[3073, 5521, 5351]  #Tz, Sz, ADT
-    ominreq=[3073, 5351]  #Tz, ADT
+    ominreq=[3073, 5521, 5351]  #Tz, Sz, ADT
+#   ominreq=[3073, 5351]  #Tz, ADT
 #   ominreq=[3073]  #Tz,
 #   ominreq[3073, 5521]  #Tz, Sz
-#    ominreq=[5351]  #ADT
+#   ominreq=[5351]  #ADT
 
     for oid in ominreq:
         if oid in typ:

--- a/src/Applications/UMD_Etc/UMD_utils/ocean_obs.py
+++ b/src/Applications/UMD_Etc/UMD_utils/ocean_obs.py
@@ -1295,14 +1295,13 @@ if list_of_obs:
         fh.write(str(nobs)+'\n')
 
 #   check to make sure minimum observation types are in gmao- file
-#   instrument check (i.e. ARGO) follows below
-    ominreq=[3073, 5521, 5351]  #Tz, Sz, ADT
-#   ominreq=[3073, 5351]  #Tz, ADT
-#   ominreq=[3073]  #Tz,
-#   ominreq[3073, 5521]  #Tz, Sz
-#   ominreq=[5351]  #ADT
+    minreq=[3073, 5521, 5351]  #Tz, Sz, ADT
+#   minreq=[3073, 5351]  #Tz, ADT
+#   minreq=[3073]  #Tz,
+#   minreq[3073, 5521]  #Tz, Sz
+#   minreq=[5351]  #ADT
 
-    for oid in ominreq:
+    for oid in minreq:
         if oid in typ:
             print("Yes,found in List : ",oid, inv_dict(obsid_dict, oid))
         else:


### PR DESCRIPTION
Problem:
@lren20 identified that some ODAS cycles ran without Argo data in 2024. The issue was caused by DBOSS updating observation files in a morning window for the current and past years. This caused spurious inconsistencies in the number of observations between the 1st and 2nd passes of the ODAS.

This PR:
- Adds a function in oncean_obs.py to crash the model from the ODAS if a required observation file is not located. This function is applied in the argo reader, for both ARGO_T and ARGO_S
- Adds a function to wait on a predetermined file age (5 minutes), so that the observer will wait while the file is younger than age.
- Updates minimum observation requirements to T and S profiles, and ADT observations.

Tests:
- Ran model with 2025/01/01 initialization, and obtained expected behavior.
- @lren20 tested zero diffs in temp and salt increments with a past run. Also performed tests on expected behavior for when an argo file was not present or was too young.