### PR TITLE
Remove SLES12 mentions at NCCS

### DIFF
--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -1868,10 +1868,6 @@ if ( $SITE == 'NCCS' ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 
-# We set some variables only on SLES15 at NCCS
-set OS_VERSION=\`grep VERSION_ID /etc/os-release | cut -d= -f2 | cut -d. -f1 | sed 's/"//g'\`
-
-if ( \$OS_VERSION == 15 ) then
     setenv I_MPI_FABRICS shm:ofi
     setenv I_MPI_OFI_PROVIDER psm3
 #    setenv I_MPI_FALLBACK 0
@@ -1888,12 +1884,6 @@ if ( \$OS_VERSION == 15 ) then
 #    setenv I_MPI_ADJUST_BCAST 11
 #    setenv I_MPI_ADJUST_REDUCE_SCATTER 4
 #    setenv I_MPI_ADJUST_BARRIER 9
-else
-    setenv I_MPI_SHM_HEAP_VSIZE 512
-    setenv PSM2_MEMORY large
-    setenv I_MPI_EXTRA_FILESYSTEM 1
-    setenv I_MPI_EXTRA_FILESYSTEM_FORCE gpfs
-endif
 EOF
 
 endif # if NCCS

--- a/src/g5_modules
+++ b/src/g5_modules
@@ -76,9 +76,6 @@ if (($node =~ discover*) || ($node =~ borg*)  || \
 
    set site = "NCCS"
 
-   # NCCS now has both SLES15 and SLES12 machines
-   set OS_VERSION=`grep VERSION_ID /etc/os-release | cut -d= -f2 | cut -d. -f1 | sed 's/"//g'`
-
 else if (($node =~ pfe*) || ($node =~ afe*) || \
          ($node =~ r[0-9]*i[0-9]*n[0-9]*) || \
          ($node =~ r[0-9]*c[0-9]*t[0-9]*n[0-9]*)) then
@@ -136,35 +133,17 @@ if ( $site == NCCS ) then
 
    set mod1 = GEOSenv
 
-   if ( $OS_VERSION == 12 ) then
+   set mod2 = comp/gcc/12.3.0
+   set mod3 = comp/intel/2021.6.0
 
-      set mod2 = comp/gcc/6.5.0
-      set mod3 = comp/intel/18.0.5.274
+   # For IMPI 2021.13
+   set basedir = /discover/swdev/mathomp4/Baselibs/ESMA-Baselibs-4.0.11-SLES12/x86_64-unknown-linux-gnu/ifort_2021.6.0-intelmpi_2021.13.0-SLES15
+   set mod4 = mpi/impi/2021.13
 
-      # For IMPI 2021.2
-      set basedir = /discover/swdev/mathomp4/Baselibs/ESMA-Baselibs-4.0.11-SLES12/x86_64-unknown-linux-gnu/ifort_18.0.5.274-intelmpi_2021.2.0-nco_2020Apr09_snapshot
-      set mod4 = mpi/impi/2021.2.0
+   set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
 
-      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-
-      set mod6 = other/mpi4py/3.1.5-py3.11/ifort_18.0.5.274-intelmpi_2021.2.0-SLES12
-      set mod7 = other/ncap2/5.1.1
-
-   else
-
-      set mod2 = comp/gcc/12.3.0
-      set mod3 = comp/intel/2021.6.0
-
-      # For IMPI 2021.13
-      set basedir = /discover/swdev/mathomp4/Baselibs/ESMA-Baselibs-4.0.11-SLES12/x86_64-unknown-linux-gnu/ifort_2021.6.0-intelmpi_2021.13.0-SLES15
-      set mod4 = mpi/impi/2021.13
-
-      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-
-      set mod6 = other/mpi4py/3.1.5-py3.11/ifort_2021.6.0-intelmpi_2021.13.0-SLES15
-      set mod7 = other/ncap2/5.2.6
-
-   endif
+   set mod6 = other/mpi4py/3.1.5-py3.11/ifort_2021.6.0-intelmpi_2021.13.0-SLES15
+   set mod7 = other/ncap2/5.2.6
 
    set momdir = /home/yvikhlia/nobackup/mom5
 
@@ -397,11 +376,7 @@ if (-e $modinit) then
 
    if ($usemodules) then
       if ($site == NCCS) then
-         if ( $OS_VERSION == 12 ) then
-            module use -a /discover/swdev/gmao_SIteam/modulefiles-SLES12
-         else
-            module use -a /discover/swdev/gmao_SIteam/modulefiles-SLES15
-         endif
+         module use -a /discover/swdev/gmao_SIteam/modulefiles-SLES15
       endif
 
       if ($site == NAS) then

--- a/src/parallel_build.csh
+++ b/src/parallel_build.csh
@@ -135,7 +135,6 @@ while ($#argv)
    if ("$1" == "-rom")  set nodeTYPE = "Rome"
    if ("$1" == "-mil")  set nodeTYPE = "Milan"
    if ("$1" == "-cas")  set nodeTYPE = "CascadeLake"
-   if ("$1" == "-c15")  set nodeTYPE = "15CascadeLake"
    if ("$1" == "-sky")  set nodeTYPE = "Skylake"
    if ("$1" == "-bro")  set nodeTYPE = "Broadwell"
    if ("$1" == "-has")  set nodeTYPE = "Haswell"
@@ -220,13 +219,12 @@ end
 # default nodeTYPE
 #-----------------
 if (! $?nodeTYPE) then
-   if ($SITE == NCCS) set nodeTYPE = "Skylake"
-   if ($SITE == NAS)  set nodeTYPE = "Skylake"
+   if ($SITE == NCCS) set nodeTYPE = "Milan"
+   if ($SITE == NAS)  set nodeTYPE = "Rome"
 endif
 
 # This is a flag needed at NCCS for Cascade Lake. Default is blank
 set ntaskspernode = ''
-set reservation = ''
 
 # at NCCS
 #--------
@@ -238,14 +236,9 @@ if ($SITE == NCCS) then
       exit 1
    endif
 
-   if ($nT == has) @ NCPUS_DFLT = 28
-   if ($nT == sky) @ NCPUS_DFLT = 40
    if ($nT == cas) @ NCPUS_DFLT = 48
-   if ($nT == 15c) @ NCPUS_DFLT = 48
    if ($nT == mil) @ NCPUS_DFLT = 126
 
-   if ($nT == has) set proc = 'hasw'
-   if ($nT == sky) set proc = 'sky'
    if ($nT == cas) then
       set proc = 'cas'
       # Adding this adds prevents a warning from NCCS about using 48
@@ -253,15 +246,6 @@ if ($SITE == NCCS) then
       # make -j48, (usually make -j10 and only asks for 10 tasks) but
       # this suppresses the warning.
       set ntaskspernode = '--ntasks-per-node=45'
-   endif
-   if ($nT == 15c) then
-      set proc = 'cas'
-      # Adding this adds prevents a warning from NCCS about using 48
-      # tasks per node on Cascade. This script will never actually run
-      # make -j48, (usually make -j10 and only asks for 10 tasks) but
-      # this suppresses the warning.
-      set ntaskspernode = '--ntasks-per-node=45'
-      set reservation = '--reservation=sles15_cas'
    endif
    if ($nT == mil) set proc = 'mil'
 
@@ -604,7 +588,6 @@ else if ( $SITE == NCCS ) then
         --nodes=1              \
         --ntasks=${numjobs}    \
         $ntaskspernode         \
-        $reservation           \
         --time=$walltime       \
         $0
    unset echo
@@ -795,8 +778,7 @@ flagged options
    -rom                 compile on Rome nodes (only at NAS)
    -mil                 compile on Milan nodes
    -cas                 compile on Cascade Lake nodes
-   -c15                 compile on Cascade Lake nodes with SLES15
-   -sky                 compile on Skylake nodes (default)
+   -sky                 compile on Skylake nodes (only at NAS)
    -bro                 compile on Broadwell nodes (only at NAS)
-   -has                 compile on Haswell nodes
+   -has                 compile on Haswell nodes (only at NAS)
 EOF


### PR DESCRIPTION
As SLES12 no longer exists at NCCS, we can remove the references to it.

This PR gets a least the ones I'm aware of in the build and setup scripts.

That said, please someone test and make sure the edits are right for S2S. I sort of based some on the current GEOSgcm