### PR TITLE
Update g5_modules to use Intel 19

### DIFF
--- a/src/g5_modules
+++ b/src/g5_modules
@@ -133,16 +133,16 @@ if ( $site == NCCS ) then
 
    set mod1 = GEOSenv
 
-   set mod2 = comp/gcc/12.3.0
-   set mod3 = comp/intel/2021.6.0
+   set mod2 = comp/gcc/9.5.0
+   set mod3 = comp/intel/19.1.3.304
 
    # For IMPI 2021.13
-   set basedir = /discover/swdev/mathomp4/Baselibs/ESMA-Baselibs-4.0.11-SLES12/x86_64-unknown-linux-gnu/ifort_2021.6.0-intelmpi_2021.13.0-SLES15
-   set mod4 = mpi/impi/2021.13
+   set basedir = /discover/swdev/mathomp4/Baselibs/ESMA-Baselibs-4.0.11-SLES12/x86_64-unknown-linux-gnu/ifort_19.1.3.304-intelmpi_2021.6.0-SLES15
+   set mod4 = mpi/impi/2021.6.0
 
    set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
 
-   set mod6 = other/mpi4py/3.1.5-py3.11/ifort_2021.6.0-intelmpi_2021.13.0-SLES15
+   set mod6 = other/mpi4py/3.1.5-py3.11/ifort_19.1.3.304-intelmpi_2021.6.0-SLES15
    set mod7 = other/ncap2/5.2.6
 
    set momdir = /home/yvikhlia/nobackup/mom5
@@ -377,6 +377,7 @@ if (-e $modinit) then
    if ($usemodules) then
       if ($site == NCCS) then
          module use -a /discover/swdev/gmao_SIteam/modulefiles-SLES15
+         module use -a /discover/swdev/gmao_SIteam/s2s_intel_modulefiles/Core
       endif
 
       if ($site == NAS) then


### PR DESCRIPTION
Per testing by @mfmehari, GEOS S2Sv3 should use Intel 19 at NCCS (which matches NAS output). This PR updates the `g5_modules` to allow this.

NOTE: I'm keeping this draft for now because there are permissions issues that need to be settled at NCCS as this compiler is not default public.