### PR TITLE
Change ncap2 modulefile

### DIFF
--- a/src/g5_modules
+++ b/src/g5_modules
@@ -143,7 +143,7 @@ if ( $site == NCCS ) then
    set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
 
    set mod6 = other/mpi4py/3.1.5-py3.11/ifort_19.1.3.304-intelmpi_2021.6.0-SLES15
-   set mod7 = other/ncap2/5.2.6
+   set mod7 = other/ncap2/5.2.6-gcc-9.5.0
 
    set momdir = /home/yvikhlia/nobackup/mom5
 


### PR DESCRIPTION
As found by S2S users (@ehackert and Yehui Chang), the `other/ncap2/5.2.6` modulefile was incompatible with the GCC 9.5.0 compiler used in GEOS-S2S-3. 

This PR updates the `g5_modules` to use a new `other/ncap2/5.2.6-gcc-9.5.0` module which does work when this `g5_modules` is `source`'d