### PR TITLE
Do not set psm3 on Cascade Lake at NCCS

### DIFF
--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -1871,7 +1871,14 @@ if ( $SITE == 'NCCS' ) then
 cat > $HOMDIR/SETENV.commands << EOF
 
     setenv I_MPI_FABRICS shm:ofi
+
+# Testing shows that the psm3 provider has issues
+# on Cascade Lake nodes. So we only set this
+# on the Milan nodes (which have 128 cores per node)
+set NUM_CORES=`grep processor /proc/cpuinfo | wc -l`
+if ( $NUM_CORES == 128 ) then
     setenv I_MPI_OFI_PROVIDER psm3
+endif
 #    setenv I_MPI_FALLBACK 0
 #    setenv I_MPI_FABRICS ofi
 #    setenv I_MPI_OFI_PROVIDER psm3


### PR DESCRIPTION
As found by @mfmehari and, well, a lot of people:

```
    setenv I_MPI_OFI_PROVIDER psm3
```
seems to trigger a failure in Intel MPI at `MPI_Init` (see traceback below).

Now, `gcm_setup` is *hardcoded* for Cascade Lake nodes, but a user might want to run on Milan.

So we make the use of the psm3 provider dependent on the number of processors on the node. If 128 (== Milan), we set this.

---

```
forrtl: severe (174): SIGSEGV, segmentation fault occurred
Image              PC                Routine            Line        Source
helloWorld.mpi2.c  000000000040403A  Unknown               Unknown  Unknown
libpthread-2.31.s  0000149C71E84910  Unknown               Unknown  Unknown
libmpi.so.12.0.0   0000149C70613EC0  Unknown               Unknown  Unknown
libmpi.so.12.0.0   0000149C70615C8C  Unknown               Unknown  Unknown
libmpi.so.12.0.0   0000149C7061CFF2  Unknown               Unknown  Unknown
libmpi.so.12.0.0   0000149C701F7C09  Unknown               Unknown  Unknown
libmpi.so.12.0.0   0000149C70495C60  Unknown               Unknown  Unknown
libmpi.so.12.0.0   0000149C7049551B  MPI_Init              Unknown  Unknown
libmpifort.so.12.  0000149C71AEC85B  PMPI_INIT             Unknown  Unknown
helloWorld.mpi2.c  0000000000402EBD  Unknown               Unknown  Unknown
helloWorld.mpi2.c  0000000000402E22  Unknown               Unknown  Unknown
libc-2.31.so       0000149C6FE3E24D  __libc_start_main     Unknown  Unknown
helloWorld.mpi2.c  0000000000402D3A  Unknown               Unknown  Unknown
==== backtrace (tid:  20528) ====
 0 0x0000000000016910 __funlockfile()  ???:0
 1 0x0000000000613ec0 match_global_settings()  /build/impi/_buildspace/release/../../src/mpid/ch4/netmod/ofi/ofi_init.c:3022
 2 0x0000000000615c8c create_vni_context()  /build/impi/_buildspace/release/../../src/mpid/ch4/netmod/ofi/ofi_init.c:2148
 3 0x000000000061cff2 MPIDI_OFI_mpi_init_hook()  /build/impi/_buildspace/release/../../src/mpid/ch4/netmod/ofi/ofi_init.c:1551
 4 0x00000000001f7c09 MPID_Init()  /build/impi/_buildspace/release/../../src/mpid/ch4/src/ch4_init.c:1530
 5 0x0000000000495c60 MPIR_Init_thread()  /build/impi/_buildspace/release/../../src/mpi/init/initthread.c:177
 6 0x000000000049551b PMPI_Init()  /build/impi/_buildspace/release/../../src/mpi/init/init.c:139
 7 0x00000000000ec85b pmpi_init_()  /build/impi/_buildspace/release/../../src/binding/fortran/mpif_h/initf.c:274
 8 0x0000000000402ebd MAIN__()  ???:0
 9 0x0000000000402e22 main()  ???:0
```