### PR TITLE
Fix bad csh-making-csh in gcm_setup

### DIFF
--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -1394,7 +1394,7 @@ if( $SITE == 'NAS' ) then
               setenv WRKDIR     /nobackup/$LOGNAME                                     # user work directory
               setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/coupled/Forcings       # Coupled Ocean/Atmos Forcing
               setenv COUPLE2DIR $COUPLEDIR                                             # For GRIDDIR2 path 
-	      setenv CPEXEC     cp                                                     # Copy utility for large copies
+              setenv CPEXEC     cp                                                     # Copy utility for large copies
               setenv TAREXEC    tar                                                    # Tar utility for large archives
               set  G5LIBDIR=/nobackup/gmao_SIteam/Utilities/ocean-scripting/python/g5lib
 else if( $SITE == 'NCCS' ) then
@@ -1436,7 +1436,7 @@ else if( $SITE == 'NCCS' ) then
               setenv WRKDIR     /discover/nobackup/$LOGNAME                            # user work directory
               setenv COUPLEDIR  /home/yvikhlia/nobackup/coupled/Forcings               # Coupled Ocean/Atmos Forcing
               setenv COUPLE2DIR /discover/nobackup/projects/gmao/geos-s2s-3/regrid_bcs # For GRIDDIR2 path
-	      setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
+              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
               setenv TAREXEC    tar                                                    # Tar utility for large archives
               set G5LIBDIR=/home/yvikhlia/python/g5lib
 else
@@ -1465,7 +1465,7 @@ else
               setenv WRKDIR     /home/$LOGNAME                                         # user work directory
               setenv COUPLEDIR  /ford1/share/gmao_SIteam/ModelData/Forcings            # Coupled Ocean/Atmos Forcing
               setenv COUPLE2DIR $COUPLEDIR                                             # For GRIDDIR2 path
-	      if( $CUBED == "TRUE" ) then
+              if( $CUBED == "TRUE" ) then
                  set NX = 1
                  set NY = 6
               else
@@ -1876,7 +1876,7 @@ cat > $HOMDIR/SETENV.commands << EOF
 # on Cascade Lake nodes. So we only set this
 # on the Milan nodes (which have 128 cores per node)
 set NUM_CORES=`grep processor /proc/cpuinfo | wc -l`
-if ( $NUM_CORES == 128 ) then
+if ( \$NUM_CORES == 128 ) then
     setenv I_MPI_OFI_PROVIDER psm3
 endif
 #    setenv I_MPI_FALLBACK 0


### PR DESCRIPTION
As found by @mfmehari, the code in #30 was not quite right as that is a csh script using a heredoc to make csh code. Thus, we have to escape the dollar-sign so `gcm_setup` doesn't try to evaluate it.

Also, my editor on my laptop apparently cleared out some tabs.