### PR TITLE
Fix a bug generating SETENV.commands in gcm_setup

### DIFF
--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -1876,7 +1876,7 @@ cat > $HOMDIR/SETENV.commands << EOF
 # on Cascade Lake nodes. So we only set this
 # on the Milan nodes (which have 128 cores per node)
 set NUM_CORES=`grep processor /proc/cpuinfo | wc -l`
-if ( $NUM_CORES == 128 ) then
+if ( \$NUM_CORES == 128 ) then
     setenv I_MPI_OFI_PROVIDER psm3
 endif
 #    setenv I_MPI_FALLBACK 0


### PR DESCRIPTION
Hi @mathomp4, this PR is a quick fix for `gcm_setup` generating the file `$HOMDIR/SETENV.commands`

https://github.com/GEOS-ESM/GEOS-S2S-3/blob/ce493aac809a027a4768b453e70fcfc22a364c7a/src/Applications/GEOSgcm_App/gcm_setup#L1875-L1881

For Line 1879, need to be `\$NUM_CORES` instead of `$NUM_CORES`, since we are in `cat` now. Otherwise `$NUM_CORES` is evaluated when running `gcm_setup`, causing the error of undefined variable for `$NUM_CORES`