### PR TITLE
Enable I_MPI_ADJUST for ALLREDUCE and GATHERV

### DIFF
--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -1871,6 +1871,8 @@ if ( $SITE == 'NCCS' ) then
 cat > $HOMDIR/SETENV.commands << EOF
 
     setenv I_MPI_FABRICS shm:ofi
+    setenv I_MPI_ADJUST_GATHERV 3
+    setenv I_MPI_ADJUST_ALLREDUCE 12
 
 # Testing shows that the psm3 provider has issues
 # on Cascade Lake nodes. So we only set this
@@ -1885,10 +1887,8 @@ endif
 #    setenv I_MPI_ADJUST_SCATTER 2
 #    setenv I_MPI_ADJUST_SCATTERV 2
 #    setenv I_MPI_ADJUST_GATHER 2
-#    setenv I_MPI_ADJUST_GATHERV 3
 #    setenv I_MPI_ADJUST_ALLGATHER 3
 #    setenv I_MPI_ADJUST_ALLGATHERV 3
-#    setenv I_MPI_ADJUST_ALLREDUCE 12
 #    setenv I_MPI_ADJUST_REDUCE 10
 #    setenv I_MPI_ADJUST_BCAST 11
 #    setenv I_MPI_ADJUST_REDUCE_SCATTER 4


### PR DESCRIPTION
Testing by Min-Seop found that he had a run that was locking up at Finalize (i.e., checkpointing).

When he tried adding (which are enable for Intel MPI in current GEOSgcm):
```
setenv I_MPI_ADJUST_ALLREDUCE 12
setenv I_MPI_ADJUST_GATHERV 3
```
things seemed to work. So, not to lose this knowledge, this PR enables those two settings.

I'm labeling as 0-diff only because with GEOSgcm it always was. I'm guessing the same is true here.