### PR TITLE
Close file in MAPL_CFIOWrite

### DIFF
--- a/src/GMAO_Shared/MAPL_Base/MAPL_CFIO.F90
+++ b/src/GMAO_Shared/MAPL_Base/MAPL_CFIO.F90
@@ -2257,6 +2257,7 @@ contains
 
          else
             Gout = Gin
+            write(*,*)'bmaa shavesend: ',maxval(gin),maxval(gout)
          endif
          deallocate(Gin)
          nullify   (Gin)
@@ -2446,6 +2447,7 @@ contains
                 VERIFY_(STATUS)
 
                 call StrToInt(date,nymd,nhms)
+                write(*,*)'bmaa before write ',maxval(Gptr2Out)
                 call ESMF_CFIOVarWrite(MCFIO%CFIO, trim(MCFIO%VARNAME(L)), &
                                        Gptr2Out, timeString=DATE,  RC=STATUS)
                 VERIFY_(STATUS)
@@ -2626,6 +2628,9 @@ contains
     VERIFY_(STATUS)
 
     call MAPL_CFIOWriteBundleWrite( MCFIO, CLOCK, RC=status)
+    VERIFY_(STATUS)
+
+    call MAPL_CFIOClose( MCFIO, RC=status)
     VERIFY_(STATUS)
 
     RETURN_(ESMF_SUCCESS)

--- a/src/GMAO_Shared/MAPL_Base/MAPL_CFIO.F90
+++ b/src/GMAO_Shared/MAPL_Base/MAPL_CFIO.F90
@@ -2257,7 +2257,6 @@ contains
 
          else
             Gout = Gin
-            write(*,*)'bmaa shavesend: ',maxval(gin),maxval(gout)
          endif
          deallocate(Gin)
          nullify   (Gin)
@@ -2447,7 +2446,6 @@ contains
                 VERIFY_(STATUS)
 
                 call StrToInt(date,nymd,nhms)
-                write(*,*)'bmaa before write ',maxval(Gptr2Out)
                 call ESMF_CFIOVarWrite(MCFIO%CFIO, trim(MCFIO%VARNAME(L)), &
                                        Gptr2Out, timeString=DATE,  RC=STATUS)
                 VERIFY_(STATUS)


### PR DESCRIPTION
it was found that when call `MAPL_CFIOWrite` the file was being created but the data wasn't being written until the end of the model execution. I traced it to the fact the file was not being closed in that procedure. Simple 2 line fix