### PR TITLE
Backport River Runoff code from GEOSgcm

### DIFF
--- a/src/GEOSgcs_GridComp/GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/src/GEOSgcs_GridComp/GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -105,7 +105,7 @@ module GEOS_SurfaceGridCompMod
   type T_Routing
      integer :: srcTileID, dstTileID,     &
                 srcIndex=-1, dstIndex=-1, &
-                srcPE=-1, dstPE=-1 
+                srcPE=-1, dstPE=-1, SeqIdx=-1
      real    :: weight
   end type T_Routing
 
@@ -3681,7 +3681,7 @@ module GEOS_SurfaceGridCompMod
     ! now everybody has blocksizes(nDEs)
 
     ntotal = sum(blocksizes) ! should be same as # of paired sources and sinks (npairs)
-    _ASSERT(ntotal==numRoutings, 'Number source/sinks does not match')
+    ASSERT_(ntotal==numRoutings)
     allocate (karray(numRoutings), stat=STATUS) !declare as target!!!
     VERIFY_(STATUS)
     karray = 0
@@ -3695,7 +3695,7 @@ module GEOS_SurfaceGridCompMod
        displ(n)=ksum
     end do
     ! as another sanity check: ksum should be the same as npairs
-    _ASSERT(displ(nDEs)==ntotal, 'Displ source/sinks does not match')
+    ASSERT_(displ(nDEs)==ntotal)
 
     allocate(kseq(nsdx), stat=STATUS)
     VERIFY_(STATUS)
@@ -9522,8 +9522,10 @@ module GEOS_SurfaceGridCompMod
       Discharge   = 0.0
 
       n=size(kdx)
-      allocate(td(n), _STAT)
-      allocate(tarray(displ(nDEs)), _STAT)
+      allocate(td(n), stat=STATUS)
+      VERIFY_(STATUS)
+      allocate(tarray(displ(nDEs)), stat=STATUS)
+      VERIFY_(STATUS)
       do k=1,n
          i=kdx(k)
 
@@ -9543,8 +9545,10 @@ module GEOS_SurfaceGridCompMod
             Discharge(Routing(i)%DstIndex) = Discharge(Routing(i)%DstIndex) + TileDischarge
          end if
       end do
-      deallocate(td, _STAT)
-      deallocate(tarray, _STAT)
+      deallocate(td, stat=STATUS)
+      VERIFY_(STATUS)
+      deallocate(tarray, stat=STATUS)
+      VERIFY_(STATUS)
 
       RETURN_(ESMF_SUCCESS)
     end subroutine RouteRunoff

--- a/src/GEOSgcs_GridComp/GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/src/GEOSgcs_GridComp/GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -109,6 +109,13 @@ module GEOS_SurfaceGridCompMod
      real    :: weight
   end type T_Routing
 
+  type T_RiverRouting
+     type(T_Routing), pointer :: LocalRoutings(:) => NULL()
+     integer, pointer :: karray(:)
+     integer, pointer :: kdx(:)
+     integer, pointer :: BlockSizes(:), displ(:)
+  end type T_RiverRouting
+
 ! Internal state and its wrapper
 ! ------------------------------
   
@@ -116,7 +123,7 @@ module GEOS_SurfaceGridCompMod
      private
      type (MAPL_LocStreamXFORM)  :: XFORM_IN (NUM_CHILDREN)
      type (MAPL_LocStreamXFORM)  :: XFORM_OUT(NUM_CHILDREN)
-     type (T_Routing), pointer   :: LocalRoutings(:) => NULL()                
+     type (T_RiverRouting), pointer   :: RoutingType => NULL()
   end type T_SURFACE_STATE
 
   type SURF_WRAP
@@ -3372,7 +3379,7 @@ module GEOS_SurfaceGridCompMod
     VERIFY_(STATUS)
 
     if (RoutingFile /= "") then
-       call InitializeRiverRouting(SURF_INTERNAL_STATE%LocalRoutings, &
+       call InitializeRiverRouting(SURF_INTERNAL_STATE%RoutingType, &
             RoutingFile, LocStream, rc=STATUS)
        VERIFY_(STATUS)
 
@@ -3412,9 +3419,9 @@ module GEOS_SurfaceGridCompMod
           call MAPL_LocStreamTransform( LOCSTREAM, PCMETILE, PCME, RC=STATUS)
           VERIFY_(STATUS)
 
-          call RouteRunoff(SURF_INTERNAL_STATE%LocalRoutings, PUMETILE, PUMEDISTILE, RC=STATUS)
+          call RouteRunoff(SURF_INTERNAL_STATE%RoutingType, PUMETILE, PUMEDISTILE, RC=STATUS)
           VERIFY_(STATUS)
-          call RouteRunoff(SURF_INTERNAL_STATE%LocalRoutings, PCMETILE, PCMEDISTILE, RC=STATUS)
+          call RouteRunoff(SURF_INTERNAL_STATE%RoutingType, PCMETILE, PCMEDISTILE, RC=STATUS)
           VERIFY_(STATUS)
 
           call MAPL_GetPointer(INTERNAL, DISCHARGE_ADJUST, 'DISCHARGE_ADJUST',  RC=STATUS)
@@ -3448,11 +3455,16 @@ module GEOS_SurfaceGridCompMod
     RETURN_(ESMF_SUCCESS)
   end subroutine Initialize
 
-  subroutine InitializeRiverRouting(LocalRoutings, RoutingFile, Stream, rc)
-    type(T_Routing), pointer         :: LocalRoutings(:)
+  subroutine InitializeRiverRouting(RoutingType, RoutingFile, Stream, rc)
+    type(T_RiverRouting), pointer    :: RoutingType
     character(len=*),        intent(IN) :: RoutingFile
     type(MAPL_LocStream), intent(IN) :: Stream
     integer, optional,    intent(OUT):: rc
+
+    type(T_Routing), pointer         :: LocalRoutings(:) => NULL()
+    integer, pointer :: karray(:)
+    integer, pointer :: kdx(:)
+    integer, pointer :: BlockSizes(:), displ(:)
 
     type(ESMF_VM)            :: VM
     integer                  :: comm, nDEs, myPE, i, numRoutings
@@ -3462,9 +3474,11 @@ module GEOS_SurfaceGridCompMod
     integer, pointer         :: Active(:,:)
     integer, pointer         :: ActiveGlobal(:,:)
     integer                  :: numActive, numLocalRoutings
-    integer, allocatable     :: BlockSizes(:), displ(:)
     integer, pointer         :: Local_Id(:)
     integer                  :: unit
+    integer :: ksum, n, nsdx
+    integer :: ntotal, k
+    integer, allocatable :: kn(:), kseq(:), tmparray(:)
 #ifdef DEBUG
     character(len=ESMF_MAXSTR)  :: routefile
 #endif
@@ -3535,6 +3549,7 @@ module GEOS_SurfaceGridCompMod
 !  assigned an index of -1.
 
        Routing => tmpLocalRoutings(i)
+       Routing%seqIdx = i
 
        call Tile2Index(Routing, Local_Id)
 
@@ -3646,6 +3661,77 @@ module GEOS_SurfaceGridCompMod
     close(unit)
 
 #endif
+
+    !ALT NEW ROUTING to make communication more effective
+
+    nsdx=0
+    do i=1,numLocalRoutings
+       !notneeded if (mype == Routing(i)%dstPE) nddx = nddx+1
+       if (mype == LocalRoutings(i)%srcPE) nsdx = nsdx+1
+    end do
+    allocate(kdx(nsdx), blocksizes(nDEs), stat=STATUS)
+    VERIFY_(STATUS)
+    blocksizes=0
+
+    ! exchange with everybody else
+    call MPI_AllGather(nsdx, 1, MP_Integer, &
+         blocksizes, 1, MP_Integer, comm, status)
+    VERIFY_(status)
+
+    ! now everybody has blocksizes(nDEs)
+
+    ntotal = sum(blocksizes) ! should be same as # of paired sources and sinks (npairs)
+    _ASSERT(ntotal==numRoutings, 'Number source/sinks does not match')
+    allocate (karray(numRoutings), stat=STATUS) !declare as target!!!
+    VERIFY_(STATUS)
+    karray = 0
+    allocate (displ(0:nDEs), stat=STATUS) !declare as target!!!
+    VERIFY_(STATUS)
+
+    ksum = 0
+    displ(0)=ksum
+    do n=1,nDEs
+       ksum = ksum + blocksizes(n)
+       displ(n)=ksum
+    end do
+    ! as another sanity check: ksum should be the same as npairs
+    _ASSERT(displ(nDEs)==ntotal, 'Displ source/sinks does not match')
+
+    allocate(kseq(nsdx), stat=STATUS)
+    VERIFY_(STATUS)
+    allocate(tmparray(numRoutings), stat=STATUS)
+    VERIFY_(STATUS)
+    ! local k index
+    k=0
+    do i=1,size(LocalRoutings)
+       if (mype==LocalRoutings(i)%srcPE) then
+          k=k+1
+          kseq(k) = LocalRoutings(i)%seqIdx
+          kdx(k) = i
+       end if
+    end do
+
+    call MPI_AllGatherV(kseq, nsdx, MP_Integer, &
+         tmparray, blocksizes, displ, MP_Integer, comm, status)
+    VERIFY_(STATUS)
+
+    deallocate(kseq)
+    do n=1,nDEs
+       do k=1,blocksizes(n)
+          i=tmparray(displ(n-1)+k)
+          karray(i)=k
+       end do
+    end do
+    deallocate(tmparray)
+
+    allocate(RoutingType, stat=STATUS)
+    VERIFY_(STATUS)
+    RoutingType%LocalRoutings => LocalRoutings
+    RoutingType%karray => karray
+    RoutingType%kdx => kdx
+    RoutingType%BlockSizes => BlockSizes
+    RoutingType%displ => displ
+
     return
 
   contains
@@ -6119,7 +6205,7 @@ module GEOS_SurfaceGridCompMod
 !-----------------------------------------------------------------------
 
     if (associated(DISCHARGE)) then
-       ASSERT_(associated(SURF_INTERNAL_STATE%LocalRoutings))
+       ASSERT_(associated(SURF_INTERNAL_STATE%RoutingType))
 !ALT       call MAPL_GetPointer(EXPORT, RUNOFF, 'RUNOFF', alloc=.true.,  RC=STATUS)
 !ALT       VERIFY_(STATUS)
     end if
@@ -6678,7 +6764,7 @@ module GEOS_SurfaceGridCompMod
 
 !ALT    call MKTILE(RUNOFF  ,RUNOFFTILE  ,NT,RC=STATUS); VERIFY_(STATUS)
 !ALT    call MKTILE(DISCHARGE,DISCHARGETILE,NT,RC=STATUS); VERIFY_(STATUS)
-    if (associated(SURF_INTERNAL_STATE%LocalRoutings) .or. DO_DATA_ATM4OCN /=0) then !routing file exists or we run DataAtm 
+    if (associated(SURF_INTERNAL_STATE%RoutingType) .or. DO_DATA_ATM4OCN /=0) then !routing file exists or we run DataAtm 
        allocate(DISCHARGETILE(NT),stat=STATUS); VERIFY_(STATUS)
        DISCHARGETILE=MAPL_Undef
        allocate(RUNOFFTILE(NT),stat=STATUS); VERIFY_(STATUS)
@@ -6808,7 +6894,7 @@ module GEOS_SurfaceGridCompMod
           ! and not to change the existing code too much
           DISCHARGETILE = RUNOFFTILE 
        else
-          call RouteRunoff(SURF_INTERNAL_STATE%LocalRoutings, RUNOFFTILE, DISCHARGETILE, RC=STATUS)
+          call RouteRunoff(SURF_INTERNAL_STATE%RoutingType, RUNOFFTILE, DISCHARGETILE, RC=STATUS)
           VERIFY_(STATUS)
        endif       
 
@@ -9398,8 +9484,8 @@ module GEOS_SurfaceGridCompMod
 
   end subroutine FILLOUT_UNGRIDDED
 
-    subroutine RouteRunoff(Routing, Runoff, Discharge, rc)
-      type(T_Routing),  intent(IN ) :: Routing(:)
+    subroutine RouteRunoff(RoutingType, Runoff, Discharge, rc)
+      type(T_RiverRouting),  intent(IN ) :: RoutingType
       real,             intent(IN ) :: Runoff(:)
       real,             intent(OUT) :: Discharge(:)
       integer, optional,intent(OUT) :: rc
@@ -9407,12 +9493,18 @@ module GEOS_SurfaceGridCompMod
       character(len=ESMF_MAXSTR)   :: IAm="RouteRunoff"
       integer                      :: STATUS
 
+      type(T_Routing), pointer :: Routing(:)
+      integer, pointer :: karray(:)
+      integer, pointer :: kdx(:)
+      integer, pointer :: BlockSizes(:), displ(:)
+
       type(ESMF_VM) :: VM
       integer       :: myPE, nDEs, comm
       integer       :: i
       real          :: TileDischarge
       integer       :: mpstatus(MP_STATUS_SIZE)
-
+      integer :: n, k
+      real, allocatable :: td(:), tarray(:)
 
       call ESMF_VMGetCurrent(VM,                                RC=STATUS)
       VERIFY_(STATUS)
@@ -9421,28 +9513,38 @@ module GEOS_SurfaceGridCompMod
       call ESMF_VMGet       (VM, localpet=MYPE, petcount=nDEs,  RC=STATUS)
       VERIFY_(STATUS)
 
+      Routing => RoutingType%LocalRoutings
+      karray => RoutingType%karray
+      kdx => RoutingType%kdx
+      BlockSizes => RoutingType%BlockSizes
+      displ => RoutingType%displ
+
       Discharge   = 0.0
 
-      do i=1,size(Routing)
-         if(Routing(i)%SrcPE==myPE) then
+      n=size(kdx)
+      allocate(td(n), _STAT)
+      allocate(tarray(displ(nDEs)), _STAT)
+      do k=1,n
+         i=kdx(k)
+
             TileDischarge = Runoff(Routing(i)%SrcIndex)*Routing(i)%weight
             TileDischarge = max(TileDischarge, 0.0)
-            if(Routing(i)%DstPE==myPE) then
-               Discharge(Routing(i)%DstIndex) = Discharge(Routing(i)%DstIndex) + TileDischarge
-            else
-               call MPI_Send(TileDischarge,1,MP_REAL,Routing(i)%DstPE,123,comm,status)
-               VERIFY_(STATUS)
-            end if
-         else
-            if(Routing(i)%DstPE==myPE) then
-               call MPI_Recv(TileDischarge,1,MP_REAL, Routing(i)%SrcPE,123,comm,mpstatus,status)
-               VERIFY_(STATUS)
-               Discharge(Routing(i)%DstIndex) = Discharge(Routing(i)%DstIndex) + TileDischarge
-            else
-               ASSERT_(.false.)
-            end if
+         td(k) = TileDischarge
+      end do
+      call MPI_AllGatherV(td, n, MP_Real, &
+           tarray, blocksizes, displ, MP_Real, comm, status)
+      VERIFY_(STATUS)
+
+      do i=1,size(Routing)
+         if(Routing(i)%DstPE==myPE) then
+            n=Routing(i)%srcPe
+            k=karray(Routing(i)%seqIdx)
+            TileDischarge=tarray(displ(n)+k)
+            Discharge(Routing(i)%DstIndex) = Discharge(Routing(i)%DstIndex) + TileDischarge
          end if
       end do
+      deallocate(td, _STAT)
+      deallocate(tarray, _STAT)
 
       RETURN_(ESMF_SUCCESS)
     end subroutine RouteRunoff


### PR DESCRIPTION
This PR backports code from @atrayano in https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/774 to allow the Surface GC to run faster:


| Component             | Old Routing (s) | New Routing (s)   | Speedup     |
|-----------------------|--------------|-------------|-------------|
| **RUN2**              | 5036.039     | 732.901     | **6.87x**   |
| RUN2_Setup            | 1.066        | 0.998       | 1.07x       |
| RUN2_GetPointers      | 19.433       | 19.560      | 0.99x       |
| RUN2_PrecipHandling   | 0.395        | 0.320       | 1.23x       |
| RUN2_SolarCalc        | 11.379       | 11.012      | 1.03x       |
| RUN2_AllocTiles       | 0.756        | 0.604       | 1.25x       |
| RUN2_TransformToTiles | 15.017       | 14.890      | 1.01x       |
| **RUN2_ChildrenLoop** | **4951.111** | **651.812** | **7.60x**   |
| RUN2_Ocean            | 522.476      | 514.985     | 1.01x       |
| RUN2_Discharge        | 4307.227     | 19.069      | **225.88x** |
| RUN2_TransformToGrid  | 31.325       | 29.005      | 1.08x       |
| RUN2_Cleanup          | 2.210        | 1.988       | 1.11x       |
| RUN2_SALTWATER        | 521.274      | 514.129     | 1.01x       |
| RUN2_LAKE             | 15.930       | 15.751      | 1.01x       |
| RUN2_LANDICE          | 27.891       | 27.716      | 1.01x       |
| RUN2_LAND             | 73.320       | 71.620      | 1.02x       |

The `RUN2_Discharge` timer is what is timing the runoff code.

With this, a 3-month run takes under 7 hours instead of 9:
```
    Walltime Used            : 06:40:22
```