### PR TITLE
Fix bug in `ESMF_CFIOUtils.F90`

### DIFF
--- a/src/Applications/MAPL_Apps/ExtDataDriver.F90
+++ b/src/Applications/MAPL_Apps/ExtDataDriver.F90
@@ -1,0 +1,40 @@
+! $Id: GEOSgcm.F90,v 1.107 2014/12/08 19:25:08 ltakacs Exp $
+
+! *********************************************************************
+! *****                      Main Program                          ****
+! *****         Finite-Volume Dynamical Core (Lin/Rood)            ****
+! *****         Forced by GEOS5 Physics              ****
+! *********************************************************************
+
+#define I_AM_MAIN
+
+#include "MAPL_Generic.h"
+
+Program ExtData_Driver
+
+
+   use MAPL_Mod
+   use ExtDataRoot_GridCompMod, only:  ROOT_SetServices => SetServices
+
+#ifdef __INTEL_COMPILER
+   use ifport
+#endif
+
+   implicit none
+   include "mpif.h"
+
+!EOP
+
+!EOC
+
+   integer           :: STATUS
+   character(len=18) :: Iam="ExtDataDriver_main"
+  
+   call MAPL_CAP(ROOT_SetServices, FinalFile='EGRESS', rc=STATUS)
+   VERIFY_(STATUS)
+
+   call exit(0)
+
+ end Program ExtData_Driver
+
+!EOC

--- a/src/Applications/MAPL_Apps/ExtDataRoot_GridComp.F90
+++ b/src/Applications/MAPL_Apps/ExtDataRoot_GridComp.F90
@@ -1,0 +1,92 @@
+
+!-------------------------------------------------------------------------
+!     NASA/GSFC, Global Modeling and Assimilation Office, Code 610.1     !
+!-------------------------------------------------------------------------
+!
+#include "MAPL_Generic.h"
+
+MODULE ExtDataRoot_GridCompMod
+      use ESMF
+      use MAPL_Mod
+      use, intrinsic :: iso_fortran_env, only: REAL64
+
+      IMPLICIT NONE
+      PRIVATE
+
+      PUBLIC SetServices
+
+
+   contains
+
+      subroutine SetServices ( GC, RC )
+
+! !ARGUMENTS:
+
+         type(ESMF_GridComp), intent(INOUT) :: GC  ! gridded component
+         integer,             intent(  OUT) :: RC  ! return code
+
+
+         character(len=ESMF_MAXSTR) :: Iam='ss'
+         integer :: status
+
+         call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE,  Initialize_, rc=status)
+         VERIFY_(STATUS)
+         call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,   Run_, rc=status)
+         VERIFY_(STATUS)
+
+         call MAPL_AddImportSpec(GC,&
+               short_name='var_2d', &
+               long_name='na' , &
+               units = 'na', &
+               dims = MAPL_DimsHorzOnly, &
+               vlocation = MAPL_VLocationNone, rc=status)
+         VERIFY_(STATUS)
+
+         call MAPL_GenericSetServices ( GC, rc=status)
+         VERIFY_(STATUS)
+
+
+      end subroutine SetServices
+
+      SUBROUTINE Initialize_ ( GC, IMPORT, EXPORT, CLOCK, rc )
+
+         implicit NONE
+
+         type(ESMF_Clock),  intent(inout) :: CLOCK     ! The clock
+
+         type(ESMF_GridComp), intent(inout) :: GC      ! Grid Component
+         type(ESMF_State), intent(inout) :: IMPORT     ! Import State
+         type(ESMF_State), intent(inout) :: EXPORT     ! Export State
+         integer, intent(out)            :: rc         ! Error return code:
+
+         character(len=ESMF_MAXSTR) :: Iam='init'
+         integer :: status
+
+         call MAPL_GridCreate(GC, rc=status)
+         VERIFY_(STATUS)
+        
+    call MAPL_GenericInitialize ( GC, import, export, clock, rc=status )
+    VERIFY_(STATUS) 
+         rc = 0
+
+      END SUBROUTINE Initialize_
+
+      SUBROUTINE Run_ ( GC, IMPORT, EXPORT, CLOCK, rc )
+
+         implicit NONE
+
+         type(ESMF_Clock),  intent(inout) :: CLOCK     ! The clock
+
+         type(ESMF_GridComp), intent(inout)  :: GC     ! Grid Component
+         type(ESMF_State), intent(inout) :: IMPORT     ! Import State
+         type(ESMF_State), intent(inout) :: EXPORT     ! Export State
+         integer, intent(out) ::  rc                   ! Error return code:
+
+         integer :: status
+         character(len=ESMF_MAXSTR) :: Iam='run'
+
+         rc = 0
+      END SUBROUTINE Run_
+
+end module ExtDataRoot_GridCompMod
+

--- a/src/Applications/MAPL_Apps/GNUmakefile
+++ b/src/Applications/MAPL_Apps/GNUmakefile
@@ -1,0 +1,162 @@
+# ----------------------------
+ifndef ESMADIR
+       ESMADIR := $(PWD)/../..
+endif
+
+# Compilation rules, flags, etc
+# -----------------------------
+  include $(ESMADIR)/Config/ESMA_base.mk  # Generic stuff
+  include $(ESMADIR)/Config/ESMA_arch.mk  # System dependencies
+  include $(ESMADIR)/Config/GMAO_base.mk  # GMAO Generic stuff
+
+  include $(ESMADIR)/Config/vectorize.mk  # Vectorize
+
+#                  ---------------------
+#                  Standard ESMA Targets
+#                  ---------------------
+
+esma_help help:
+	@echo "Standard ESMA targets:"
+
+THIS = ExtDataDriver
+BINS = $(THIS).x
+
+esma_install install: $(BINS)
+	$(MKDIR) $(ESMABIN) $(ESMAETC)
+	$(CP) -p *.x    $(ESMABIN)
+
+esma_clean clean:
+	-$(RM) *~ *.[aox] *.mod *.x $(GCMDOC).*
+
+esma_distclean distclean:
+	-$(RM) *~ *.[aoxd] *.mod *.x $(GCMDOC).*
+
+#                  ---------------------------
+#                  Availability Driven Options
+#                  ---------------------------
+
+LIB_SHARED = $(wildcard \
+             $(ESMALIB)/libMAPL_Base.a \
+             $(ESMALIB)/libMAPL_cfio_r4.a \
+             $(ESMALIB)/libGMAO_gfio_r4.a \
+             $(ESMALIB)/libGMAO_mpeu.a  )
+
+
+
+#                  --------------------
+#                  User Defined Targets
+#                  --------------------# Make sure ESMADIR is defined
+# ----------------------------
+ifndef ESMADIR
+       ESMADIR := $(PWD)/../..
+endif
+
+# Compilation rules, flags, etc
+# -----------------------------
+  include $(ESMADIR)/Config/ESMA_base.mk  # Generic stuff
+  include $(ESMADIR)/Config/ESMA_arch.mk  # System dependencies
+  include $(ESMADIR)/Config/GMAO_base.mk  # GMAO Generic stuff
+
+  include $(ESMADIR)/Config/vectorize.mk  # Vectorize
+
+#                  ---------------------
+#                  Standard ESMA Targets
+#                  ---------------------
+
+esma_help help:
+	@echo "Standard ESMA targets:"
+
+THIS = ExtDataDriver
+BINS = $(THIS).x
+
+esma_install install: $(BINS)
+	$(MKDIR) $(ESMABIN) $(ESMAETC) 
+	$(CP) -p *.x    $(ESMABIN)
+	$(CP) -p *.rc   $(ESMAETC)
+	$(CP) -p *.tmpl $(ESMAETC)
+
+esma_clean clean:
+	-$(RM) *~ *.[aox] *.mod *.x $(GCMDOC).*
+
+esma_distclean distclean:
+	-$(RM) *~ *.[aoxd] *.mod *.x $(GCMDOC).*
+
+#                  ---------------------------
+#                  Availability Driven Options
+#                  ---------------------------
+ifeq ( $(wildcard $(ESMALIB)/libmom.a), $(null) )
+ifeq ($(FV_PRECISION), R4)
+   LIB_FMS = $(ESMALIB)/libGFDL_fms_r4.a
+else
+   LIB_FMS = $(ESMALIB)/libGFDL_fms_r8.a
+endif
+else
+   LIB_FMS = $(ESMALIB)/libGFDL_fms_r8.a
+endif
+
+#LIB_DYN = $(wildcard $(ESMALIB)/libFVdycoreCubed_GridComp.a $(LIB_FMS) )
+
+LIB_DYN = $(wildcard $(ESMALIB)/libGEOSsingcol_GridComp.a\
+                     $(ESMALIB)/libGEOSsuperdyn_GridComp.a\
+                     $(ESMALIB)/libGEOStopo_GridComp.a\
+                     $(ESMALIB)/libFVdycore_GridComp.a \
+                     $(ESMALIB)/libFVdycoreCubed_GridComp.a \
+                     $(ESMALIB)/libARIESg3_GridComp.a \
+                     $(ESMALIB)/libGEOSdatmodyn_GridComp.a\
+                     $(LIB_FMS) \
+                     $(ESMALIB)/libfvdycore.a \
+                     $(ESMALIB)/libGMAO_pilgrim.a \
+                     $(ESMALIB)/libGEOSdataatm_GridComp.a)
+
+
+LIB_SHARED = $(wildcard \
+             $(ESMALIB)/libMAPL_Base.a \
+             $(ESMALIB)/libMAPL_cfio_r4.a \
+             $(ESMALIB)/libGMAO_gfio_r4.a \
+             $(ESMALIB)/libGMAO_mpeu.a  )
+
+
+
+#                  --------------------
+#                  User Defined Targets
+#                  --------------------
+FREAL = $(FREAL4)
+#SRCS = $(THIS).F90 ExtDataRoot_GridComp.F90   # <-- CHANGED
+SRCS = ExtDataRoot_GridComp.F90 $(THIS).F90 # <-- CHANGED
+OBJS = $(SRCS:.F90=.o)
+
+DIR_GC = $(wildcard $(ESMAINC)/GEOS[a-z]*GridComp $(INC_GEOSCHEM) )  
+INC_GC = $(foreach FF,$(DIR_GC),$(M)$(FF))
+
+INC_DIRS = . $(INC_GEOS_GCS) $(INC_GMAO_SHARED) $(INC_ESMF) $(INC_MPI)
+MOD_DIRS = . $(INC_DIRS)
+
+USER_FINCS  = $(foreach dir,$(INC_DIRS),$(I)$(dir))
+USER_FMODS  = $(foreach dir,$(MOD_DIRS),$(M)$(dir))
+USER_FFLAGS = $(USER_DEFS) $(BIG_ENDIAN)
+USER_LDFLAGS += $(MCMODEL)
+
+vpath % $(MOD_DIRS)
+
+LIB_COMP = $(LIB_DYN) $(LIB_SHARED)
+
+ifeq ($(LIB_SDF),$(LIB_HDF))
+   LIB_SDF :=  $(ESMALIB)/libGMAO_mfhdf3.a $(LIB_SDF)
+endif
+
+$(THIS).x : $(OBJS) $(LIB_COMP)
+	$(LD) -o $@ $(LDFLAGS) $(OBJS)  \
+                                   -Wl,--start-group $(LIB_COMP) -Wl,--end-group $(LIB_APROF)   \
+                                   $(LIB_ESMF) $(LIB_SDF) \
+                                   $(LIB_SCI) $(LIB_MPI) $(LIB_SYS)
+
+#                  --------------------
+#                      Dependencies
+#                  --------------------
+
+$(THIS).o: $(LIB_COMP)
+ExtDataRoot_GridComp.o: $(LIB_COMP)
+
+  -include $(ESMADIR)/Config/ESMA_post.mk  # ESMA additional targets, macros
+
+#.

--- a/src/Applications/MAPL_Apps/hold_GNUmakefile
+++ b/src/Applications/MAPL_Apps/hold_GNUmakefile
@@ -1,0 +1,139 @@
+# ----------------------------
+ifndef ESMADIR
+       ESMADIR := $(PWD)/../..
+endif
+
+# Compilation rules, flags, etc
+# -----------------------------
+  include $(ESMADIR)/Config/ESMA_base.mk  # Generic stuff
+  include $(ESMADIR)/Config/ESMA_arch.mk  # System dependencies
+  include $(ESMADIR)/Config/GMAO_base.mk  # GMAO Generic stuff
+
+  include $(ESMADIR)/Config/vectorize.mk  # Vectorize
+
+#                  ---------------------
+#                  Standard ESMA Targets
+#                  ---------------------
+
+esma_help help:
+	@echo "Standard ESMA targets:"
+
+THIS = ExtDataDriver
+BINS = $(THIS).x
+
+esma_install install: $(BINS)
+	$(MKDIR) $(ESMABIN) $(ESMAETC)
+	$(CP) -p *.x    $(ESMABIN)
+	$(CP) -p *.rc   $(ESMAETC)
+	$(CP) -p *.tmpl $(ESMAETC)
+
+esma_clean clean:
+	-$(RM) *~ *.[aox] *.mod *.x $(GCMDOC).*
+
+esma_distclean distclean:
+	-$(RM) *~ *.[aoxd] *.mod *.x $(GCMDOC).*
+
+#                  ---------------------------
+#                  Availability Driven Options
+#                  ---------------------------
+
+LIB_SHARED = $(wildcard \
+             $(ESMALIB)/libMAPL_Base.a \
+             $(ESMALIB)/libMAPL_cfio_r4.a \
+             $(ESMALIB)/libGMAO_gfio_r4.a \
+             $(ESMALIB)/libGMAO_mpeu.a  )
+
+
+
+#                  --------------------
+#                  User Defined Targets
+#                  --------------------# Make sure ESMADIR is defined
+# ----------------------------
+ifndef ESMADIR
+       ESMADIR := $(PWD)/../..
+endif
+
+# Compilation rules, flags, etc
+# -----------------------------
+  include $(ESMADIR)/Config/ESMA_base.mk  # Generic stuff
+  include $(ESMADIR)/Config/ESMA_arch.mk  # System dependencies
+  include $(ESMADIR)/Config/GMAO_base.mk  # GMAO Generic stuff
+
+  include $(ESMADIR)/Config/vectorize.mk  # Vectorize
+
+#                  ---------------------
+#                  Standard ESMA Targets
+#                  ---------------------
+
+esma_help help:
+	@echo "Standard ESMA targets:"
+
+THIS = ExtDataDriver
+BINS = $(THIS).x
+
+esma_install install: $(BINS)
+	$(MKDIR) $(ESMABIN) $(ESMAETC) 
+	$(CP) -p *.x    $(ESMABIN)
+	$(CP) -p *.rc   $(ESMAETC)
+	$(CP) -p *.tmpl $(ESMAETC)
+
+esma_clean clean:
+	-$(RM) *~ *.[aox] *.mod *.x $(GCMDOC).*
+
+esma_distclean distclean:
+	-$(RM) *~ *.[aoxd] *.mod *.x $(GCMDOC).*
+
+#                  ---------------------------
+#                  Availability Driven Options
+#                  ---------------------------
+
+LIB_SHARED = $(wildcard \
+             $(ESMALIB)/libMAPL_Base.a \
+             $(ESMALIB)/libMAPL_cfio_r4.a \
+             $(ESMALIB)/libGMAO_gfio_r4.a \
+             $(ESMALIB)/libGMAO_mpeu.a  )
+
+
+
+#                  --------------------
+#                  User Defined Targets
+#                  --------------------
+FREAL = $(FREAL4)
+#SRCS = $(THIS).F90 ExtDataRoot_GridComp.F90   # <-- CHANGED
+SRCS = ExtDataRoot_GridComp.F90 $(THIS).F90 # <-- CHANGED
+OBJS = $(SRCS:.F90=.o)
+
+DIR_GC = $(wildcard $(ESMAINC)/GEOS[a-z]*GridComp $(INC_GEOSCHEM) )  
+INC_GC = $(foreach FF,$(DIR_GC),$(M)$(FF))
+
+INC_DIRS = . $(INC_GEOS_GCS) $(INC_GMAO_SHARED) $(INC_ESMF) $(INC_MPI)
+MOD_DIRS = . $(INC_DIRS)
+
+USER_FINCS  = $(foreach dir,$(INC_DIRS),$(I)$(dir))
+USER_FMODS  = $(foreach dir,$(MOD_DIRS),$(M)$(dir))
+USER_FFLAGS = $(USER_DEFS) $(BIG_ENDIAN)
+USER_LDFLAGS += $(MCMODEL)
+
+vpath % $(MOD_DIRS)
+
+LIB_COMP = $(LIB_SHARED)
+
+ifeq ($(LIB_SDF),$(LIB_HDF))
+   LIB_SDF :=  $(ESMALIB)/libGMAO_mfhdf3.a $(LIB_SDF)
+endif
+
+$(THIS).x : $(OBJS) $(LIB_COMP)
+	$(LD) -o $@ $(LDFLAGS) $*.o -Wl,--start-group $(LIB_COMP) -Wl,--end-group $(LIB_APROF)   \
+                                   $(LIB_ESMF) $(LIB_SDF) \
+                                   $(LIB_SCI) $(LIB_MPI) $(LIB_SYS)
+
+#                  --------------------
+#                      Dependencies
+#                  --------------------
+
+$(THIS).o: $(LIB_COMP)
+ExtDataRoot_GridComp.o: $(LIB_COMP)
+
+  -include $(ESMADIR)/Config/ESMA_post.mk  # ESMA additional targets, macros
+
+#.

--- a/src/GMAO_Shared/MAPL_cfio/ESMF_CFIOUtilMod.F90
+++ b/src/GMAO_Shared/MAPL_cfio/ESMF_CFIOUtilMod.F90
@@ -761,7 +761,7 @@
                 corner(1) = i
                 rc = NF90_GET_VAR(fid,timeID,ltime_array,corner,(/1/))
                 ltime = ltime_array(1)
-                incVecLong(i) = time_to_seconds_i16(timeUnits, ltime)
+                incVecLong(i) = time_to_seconds_i32(timeUnits, ltime)
            else
                 if (err("GetDateTimeVec: invalid time data type",&
                    1,-44) .NE. 0) return

--- a/src/GMAO_Shared/MAPL_cfio/ESMF_CFIOUtilMod.F90
+++ b/src/GMAO_Shared/MAPL_cfio/ESMF_CFIOUtilMod.F90
@@ -746,46 +746,33 @@
                 corner(1) = i
                 rc = NF90_GET_VAR(fid,timeID,rtime_array,corner,(/1/))
                 rtime = rtime_array(1)
-                incVecLong(i) = int(rtime,8) 
+                incVecLong(i) = time_to_seconds_sp(timeUnits, rtime)
            else if ( type .eq. NF90_DOUBLE ) then
                 corner(1) = i
                 rc = NF90_GET_VAR(fid,timeID,dtime_array,corner,(/1/))
                 dtime = dtime_array(1)
-                incVecLong(i) = int(dtime,8)
+                incVecLong(i) = time_to_seconds_dp(timeUnits, dtime)
            else if ( type .eq. NF90_SHORT  ) then
                 corner(1) = i
                 rc = NF90_GET_VAR(fid,timeID,itime_array,corner,(/1/))
                 itime = itime_array(1)
-                incVecLong(i) = int(itime,8)
+                incVecLong(i) = time_to_seconds_i16(timeUnits, itime)
            else if ( type .eq. NF90_INT   ) then
                 corner(1) = i
                 rc = NF90_GET_VAR(fid,timeID,ltime_array,corner,(/1/))
                 ltime = ltime_array(1)
-                incVecLong(i) = int(ltime,8)
+                incVecLong(i) = time_to_seconds_i16(timeUnits, ltime)
            else
                 if (err("GetDateTimeVec: invalid time data type",&
                    1,-44) .NE. 0) return
            endif
       end do
 
-!     Convert time increment to seconds if necessary
-!     ----------------------------------------------
-      if ( timeUnits(1:6) .eq.  'minute' ) then
-           tMultLong = 60 
-      else if ( timeUnits(1:4) .eq. 'hour'   ) then
-           tMultLong = 60 * 60 
-      else if ( timeUnits(1:3) .eq.  'day' ) then
-           tMultLong = 60 * 60 * 24
-      else
-           if (err("GetDateTimeVec: invalid time unit name",&
-              1,-44) .NE. 0) return
-      endif
-
 !     Combine the first time offset with the reference time to get the beginning
 !     date and time
 !     -----------------------------------------------------------------------------
       t1Long = incVecLong(1)
-      Call GetDate(begDate,begTime,t1Long*tMultLong,newDate,newTime,rc)
+      Call GetDate(begDate,begTime,t1Long,newDate,newTime,rc)
       begDate=newDate
       begTime=newTime
 
@@ -794,7 +781,7 @@
       incVec(:) = 0
       do i=1,dimsize
          t2Long = incVecLong(i)
-         incSecsLong = (t2Long - t1Long)*tMultLong
+         incSecsLong = t2Long - t1Long
          ! If (incSecsLong.gt.huge(t1)) Then
          !   print *, 'Time interval too large'
          !   rc = -10
@@ -811,6 +798,188 @@
       rc = 0 ! all done
 
       return
+
+      contains
+
+!==============================================================================
+! Helper subroutine: parse the time unit word from a "unit since date" string
+!==============================================================================
+subroutine parse_time_unit(units_str, unit_word)
+    implicit none
+
+    character(len=*), intent(in)  :: units_str
+    character(len=32), intent(out) :: unit_word
+
+    integer :: space_pos
+
+    ! Find the position of the first space
+    space_pos = index(trim(units_str), ' ')
+
+    if (space_pos == 0) then
+        ! No space found, the entire string is the unit word
+        unit_word = trim(units_str)
+    else
+        ! Take everything before the first space
+        unit_word = units_str(1:space_pos-1)
+    end if
+
+    ! Convert to lowercase to make matching case-insensitive
+    call to_lowercase(unit_word)
+
+end subroutine parse_time_unit
+
+
+!==============================================================================
+! Helper subroutine: convert a string to lowercase
+!==============================================================================
+subroutine to_lowercase(str)
+    implicit none
+
+    character(len=*), intent(inout) :: str
+
+    integer :: i, ascii_val
+
+    do i = 1, len_trim(str)
+        ascii_val = iachar(str(i:i))
+        if (ascii_val >= 65 .and. ascii_val <= 90) then
+            str(i:i) = achar(ascii_val + 32)
+        end if
+    end do
+
+end subroutine to_lowercase
+
+
+!==============================================================================
+! Function 1: Convert SINGLE PRECISION time value to seconds (INT64)
+!==============================================================================
+function time_to_seconds_sp(units, value) result(seconds)
+    use iso_fortran_env, only: int64
+    implicit none
+
+    character(len=*), intent(in) :: units
+    real(kind=4),     intent(in) :: value
+    integer(int64)               :: seconds
+    real(kind=4)                 :: total_seconds
+    character(len=32)            :: unit_word
+
+    call parse_time_unit(units, unit_word)
+
+    select case (trim(unit_word))
+        case ('seconds', 'second', 'sec', 's')
+            total_seconds = value
+        case ('minutes', 'minute', 'min', 'm')
+            total_seconds = value * 60.0e0
+        case ('hours', 'hour', 'hr', 'h')
+            total_seconds = value * 3600.0e0
+        case ('days', 'day', 'd')
+            total_seconds = value * 86400.0e0
+        case default
+            write(*,*) 'ERROR: Unknown time unit "', trim(unit_word), '"'
+            seconds = -1_int64
+            return
+    end select
+
+    seconds = nint(total_seconds, kind=int64)
+
+end function time_to_seconds_sp
+
+
+!==============================================================================
+! Function 2: Convert DOUBLE PRECISION time value to seconds (INT64)
+!==============================================================================
+function time_to_seconds_dp(units, value) result(seconds)
+    use iso_fortran_env, only: int64
+    implicit none
+
+    character(len=*), intent(in) :: units
+    real(kind=8),     intent(in) :: value
+    integer(int64)               :: seconds
+    real(kind=8)                 :: total_seconds
+    character(len=32)            :: unit_word
+
+    call parse_time_unit(units, unit_word)
+
+    select case (trim(unit_word))
+        case ('seconds', 'second', 'sec', 's')
+            total_seconds = value
+        case ('minutes', 'minute', 'min', 'm')
+            total_seconds = value * 60.0d0
+        case ('hours', 'hour', 'hr', 'h')
+            total_seconds = value * 3600.0d0
+        case ('days', 'day', 'd')
+            total_seconds = value * 86400.0d0
+        case default
+            write(*,*) 'ERROR: Unknown time unit "', trim(unit_word), '"'
+            seconds = -1_int64
+            return
+    end select
+
+    seconds = nint(total_seconds, kind=int64)
+
+end function time_to_seconds_dp
+
+
+!==============================================================================
+! Function 3: Convert 16-BIT INTEGER time value to seconds (INT64)
+!==============================================================================
+function time_to_seconds_i16(units, value) result(seconds)
+    use iso_fortran_env, only: int16, int64
+    implicit none
+
+    character(len=*), intent(in) :: units
+    integer(int16),   intent(in) :: value
+    integer(int64)               :: seconds
+    character(len=32)            :: unit_word
+
+    call parse_time_unit(units, unit_word)
+
+    select case (trim(unit_word))
+        case ('seconds', 'second', 'sec', 's')
+            seconds = int(value, kind=int64)
+        case ('minutes', 'minute', 'min', 'm')
+            seconds = int(value, kind=int64) * 60_int64
+        case ('hours', 'hour', 'hr', 'h')
+            seconds = int(value, kind=int64) * 3600_int64
+        case ('days', 'day', 'd')
+            seconds = int(value, kind=int64) * 86400_int64
+        case default
+            write(*,*) 'ERROR: Unknown time unit "', trim(unit_word), '"'
+            seconds = -1_int64
+    end select
+
+end function time_to_seconds_i16
+
+
+!==============================================================================
+! Function 4: Convert 32-BIT INTEGER time value to seconds (INT64)
+!==============================================================================
+function time_to_seconds_i32(units, value) result(seconds)
+    use iso_fortran_env, only: int32, int64
+    implicit none
+
+    character(len=*), intent(in) :: units
+    integer(int32),   intent(in) :: value
+    integer(int64)               :: seconds
+    character(len=32)            :: unit_word
+
+    call parse_time_unit(units, unit_word)
+
+    select case (trim(unit_word))
+        case ('seconds', 'second', 'sec', 's')
+            seconds = int(value, kind=int64)
+        case ('minutes', 'minute', 'min', 'm')
+            seconds = int(value, kind=int64) * 60_int64
+        case ('hours', 'hour', 'hr', 'h')
+            seconds = int(value, kind=int64) * 3600_int64
+        case ('days', 'day', 'd')
+            seconds = int(value, kind=int64) * 86400_int64
+        case default
+            write(*,*) 'ERROR: Unknown time unit "', trim(unit_word), '"'
+            seconds = -1_int64
+    end select
+
+end function time_to_seconds_i32
+
       end subroutine GetDateTimeVec
 
 


### PR DESCRIPTION
Mike Mehari found that ExtData was not correctly reading the JRA55 files that have data every 3 hours. It was only updating the fields once per day.

I ultimately traced this down to a bug in the `ESMF_CFIOUtils.F90` file. That had a routine that returns the time information from the file as a start date, a start time, and a 64 bit integer vector of the deltas from the that time. However, depending on type (real32, real64 etc...) this was not being done correctly as it was not converting the time variable to int64 seconds correctly due to using `INT` on a real number and losing information. For example it would return 1.2 days, 1.4 days etc all as 86400 seconds.

This fixes that routine. Note that the helper procedures I needed to fix this properly were generated with chatGSFC for expediency.

In addition I am getting frustrated with not having an easy way to run ExtData by itself. Modern MAPL has a utility to do this that is not back portable to this codebase. I have created a very simple grid comp and driver I can use to run ExtData should any more problems be found that I would need to debug. I have put that in a folder in the Apps directory.

If any code was relying on the wrong results that the routine in `ESMF_CFIOUtils.F90` this would be non-zero diff but that was flat out bug in that routine.