### PR TITLE
WIP: Add support for Athena/Turin

### DIFF
--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -122,6 +122,15 @@ if ( $SITE != 'NCCS' && $SITE != 'NAS' ) then
    set NOCVS = TRUE
 endif
 
+if ( $SITE == 'NAS') then
+   set OS_VERSION_ID=`grep VERSION_ID /etc/os-release | cut -d= -f2 | cut -d. -f1 | sed 's/"//g'`
+   if ( "$OS_VERSION_ID" == "8" ) then
+      set TOSS_VERSION = "TOSS4"
+   else if ( "$OS_VERSION_ID" == "9" ) then
+      set TOSS_VERSION = "TOSS5"
+   endif
+endif
+
 #######################################################################
 #           CVS: Test for Environment Variable
 #######################################################################
@@ -174,6 +183,8 @@ else if ( `echo $BASEDIR | grep -i intelmpi` != '') then
    set MPI = intelmpi
 else if ( `echo $BASEDIR | grep -i mpt`      != '') then
    set MPI = mpt
+else if ( `echo $BASEDIR | grep -i craympich` != '') then
+   set MPI = craympich
 else
    # Assume default is Intel MPI in case of older baselibs
    set MPI = intelmpi 
@@ -192,6 +203,8 @@ if ( $MPI == mvapich2 ) then
 else if ( $MPI == openmpi ) then
    setenv RUN_CMD 'mpirun -map-by core -bind-to core -np ' # mpi run for OpenMPI 
 else if ( $MPI == intelmpi ) then
+   setenv RUN_CMD 'mpirun -np '              # mpi run for Intel MPI
+else if ( $MPI == craympich ) then
    setenv RUN_CMD 'mpirun -np '              # mpi run for Intel MPI
 else if ( $MPI == mpt ) then
    setenv RUN_CMD 'mpiexec_mpt -np '         # mpi run for MPT
@@ -1366,9 +1379,15 @@ if( $SITE == 'NAS' ) then
                  set MODEL = "san_gpu"                                                 # Model of CPU
                  set QTYPE = "gpu_k40"                                                 # Queue to use
               else
-                 set NCPUS = 120                                                       # CPUS per node
-                 set MODEL = "rom_ait"                                                 # Model of CPU
-                 set QTYPE = "normal"                                                  # Queue to use
+                 if ( "$TOSS_VERSION" == "TOSS4" ) then
+                    set NCPUS = 120                                                       # CPUS per node
+                    set MODEL = "rom_ait"                                                 # Model of CPU
+                    set QTYPE = "normal"                                                  # Queue to use
+                 else
+                    set NCPUS = 240                                                       # CPUS per node
+                    set MODEL = "tur_ath"                                                 # Model of CPU
+                    set QTYPE = "normal"                                                  # Queue to use
+                 endif
               endif
               @ NCUS  = `echo "($NPES + $NCPUS - 1)/$NCPUS" | bc`
               @ NPCUS = `echo "($POST_NPES + $NCPUS - 1)/$NCPUS" | bc`
@@ -1901,6 +1920,23 @@ endif
 EOF
 
 endif # if NCCS
+
+else if ( $MPI == craympich ) then
+
+if ( $SITE == 'NAS' ) then
+
+cat > $HOMDIR/SETENV.commands << EOF
+# Testing on Athena/Turin at NAS shows these
+# settings are needed for oserver use
+# NOTE: These should probably only be used by
+# *Cray* MPICH at NAS, but for now, that's
+# the only MPICH being used there.
+
+setenv FI_CXI_OPTIMIZED_MRS 0
+setenv FI_CXI_RX_MATCH_MODE hybrid
+EOF
+
+endif # if NAS
 
 endif # if mpi
 

--- a/src/Config/mpi.mk
+++ b/src/Config/mpi.mk
@@ -22,10 +22,10 @@
       INC_MPI := $(MVAPICH2)/include
       LIB_MPI := -L$(MVAPICH2)/lib  -lmpich
   else
-  ifdef MPICH
+  ifdef MPICH_DIR
       FC := mpifort
-      INC_MPI := $(MPICH)/include
-      LIB_MPI := -L$(MPICH)/lib  -lmpifort -lmpi
+      INC_MPI := $(MPICH_DIR)/include
+      LIB_MPI := -L$(MPICH_DIR)/lib  -lmpifort -lmpi
   else
   ifdef M_MPI_ROOT
       FC := mpif90

--- a/src/GEOSgcs_GridComp/GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GNUmakefile
+++ b/src/GEOSgcs_GridComp/GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GNUmakefile
@@ -43,16 +43,16 @@ ALLDIRS = Shared \
           GEOScatch_GridComp  \
           GEOSlana_GridComp   \
           GEOScatchCN_GridComp \
-          GEOSroute_GridComp  
+          GEOSroute_GridComp
 
 SUBDIRS = $(wildcard $(ALLDIRS))
 
 TARGETS = esma_install esma_clean esma_distclean esma_doc \
-          install clean distclean doc 
+          install clean distclean doc
 
 export ESMADIR BASEDIR ARCH SITE
 
-$(TARGETS): 
+$(TARGETS):
 	@ t=$@; argv="$(SUBDIRS)" ;\
 	  for d in $$argv; do			 \
 	    ( cd $$d				;\
@@ -83,8 +83,8 @@ local_esma_doc local_doc:
 
 
 SRCS := GEOS_LandGridComp.F90
-OBJS := $(addsuffix .o, $(basename $(SRCS))) 
-DEPS := $(addsuffix .d, $(basename $(SRCS))) 
+OBJS := $(addsuffix .o, $(basename $(SRCS)))
+DEPS := $(addsuffix .d, $(basename $(SRCS)))
 
 FREAL = $(FREAL4) # for now, require 32 bit reals (R4)
 
@@ -92,9 +92,9 @@ INC_DIRS = . $(INC_GEOS_LANDSHR) $(INC_GEOS_SURFSHR) $(INC_GMAO_SHARED) $(INC_ES
 MOD_DIRS = . $(INC_DIRS) \
              $(foreach dir,$(SUBDIRS),$(ESMAINC)/$(dir))
 
-USER_FINCS  = $(foreach dir,$(INC_DIRS),$(I)$(dir)) 
-USER_FMODS  = $(foreach dir,$(MOD_DIRS),$(M)$(dir)) 
-USER_FFLAGS = $(BIG_ENDIAN) 
+USER_FINCS  = $(foreach dir,$(INC_DIRS),$(I)$(dir))
+USER_FMODS  = $(foreach dir,$(MOD_DIRS),$(M)$(dir))
+USER_FFLAGS = $(BIG_ENDIAN)
 
 vpath % $(MOD_DIRS)
 
@@ -113,16 +113,10 @@ $(LIB) lib : $(OBJS)
 #              Package Dependencies for Parallel Install
 #              ------------------------------------------
 
-   ifeq ($(wildcard GEOSroute_GridComp), $(null))
-      GEOSroute_GridComp_install = 
-   else
-      GEOSroute_GridComp_install = GEOSroute_GridComp_install
-   endif
-
-   GEOSlana_GridComp_install   : GEOScatch_GridComp_install
-   GEOScatch_GridComp_install  : Shared_install $(GEOSroute_GridComp_install)
    GEOScatchCN_GridComp_install: Shared_install
-   GEOSroute_GridComp_install  : Shared_install 
+   GEOSroute_GridComp_install  : Shared_install
+   GEOScatch_GridComp_install  : Shared_install GEOSroute_GridComp_install
+   GEOSlana_GridComp_install   : GEOScatch_GridComp_install
 
   -include $(ESMADIR)/Config/ESMA_post.mk  # ESMA additional targets, macros
 

--- a/src/g5_modules
+++ b/src/g5_modules
@@ -185,10 +185,9 @@ else if ( $site == NAS ) then
 
       set mod3 = comp-gcc/12.5.0
       set mod4 = PrgEnv-intel/8.6.0
-      set mod5 = comp-intel/2023.2.1
-      set mod6 = mpi/mpich-ifort-icc
+      set mod5 = mpi/mpich-ifort-icc
 
-      set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 )
+      set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
       set modinit = /opt/cray/pe/modules/3.2.11.7/init/csh
 
       set switchmods = ( intel/latest:intel-classic/2023.2.1 )
@@ -247,7 +246,7 @@ if ( $#argv > 0 ) then
    else if ( $1 == loadmodules ) then
       echo $loadmodules
 
-      else if ( $1 == switchmodules ) then
+   else if ( $1 == switchmodules ) then
       echo $switchmods
 
    else if ( $1 == usemodules ) then
@@ -357,6 +356,10 @@ if (-e $modinit) then
       endif
    endif
 
+   foreach mod ( $mods )
+      module load $mod
+   end
+
    if ($switchmodules) then
       foreach switchmod ( $switchmods )
          set frommodule = `echo $switchmod | cut -d: -f1`
@@ -364,10 +367,6 @@ if (-e $modinit) then
          module switch $frommodule $tomodule
       end
    endif
-
-   foreach mod ( $mods )
-      module load $mod
-   end
 
 endif
 if (! $wrapper) echo " for $node"

--- a/src/g5_modules
+++ b/src/g5_modules
@@ -7,8 +7,7 @@
 #    * provide single location for BASEDIR and module values
 #    * initialize the following:
 #      - set BASEDIR
-#      - set MOMDIR
-#      - update LD_LIBRARY_PATH with BASEDIR lib
+#      - update LD_LIBRARY_PATH with BASEDIR lib (if useldlibs is set)
 #      - load library modules
 #    * echo expected BASEDIR and library module values when queried
 #
@@ -45,7 +44,6 @@
 #  21Jul2011  Kokron   Overlay older MKL module as on discover to gain reproducible results from dgeev in GSI 
 #  24Aug2012  Stassi   Added sh option to write bash source-able file
 #  03Nov2016  Thompson Remove JIBB
-#  31Oct2017  Thompson Add momdir
 ########################################################################
 
 # NOTE: Spell out scriptname--DO NOT SET EQUAL TO $0!
@@ -76,21 +74,20 @@ if (($node =~ discover*) || ($node =~ borg*)  || \
 
    set site = "NCCS"
 
-else if (($node =~ pfe*) || ($node =~ afe*) || \
+else if (($node =~ pfe*) || ($node =~ afe*) || ($node =~ athfe*) || \
          ($node =~ r[0-9]*i[0-9]*n[0-9]*) || \
-         ($node =~ r[0-9]*c[0-9]*t[0-9]*n[0-9]*)) then
+         ($node =~ r[0-9]*c[0-9]*t[0-9]*n[0-9]*) || \
+         ($node =~ x[0-9]*c[0-9]*s[0-9]*b[0-9]*n[0-9]*) ) then
 
    # We are on NAS...
    set site = "NAS"
 
-else if ($node =~ janus*) then
-   set site = "GMAO.janus"
-
-else if ( $node =~ bender* ) then
-   set site = "ACDL.bender"
-
-else if ( $node =~ *niteroi* ) then
-   set site = "GMAO.niteroi"
+   set OS_VERSION_ID=`grep VERSION_ID /etc/os-release | cut -d= -f2 | cut -d. -f1 | sed 's/"//g'`
+   if ( "$OS_VERSION_ID" == "8" ) then
+      set TOSS_VERSION = "TOSS4"
+   else if ( "$OS_VERSION_ID" == "9" ) then
+      set TOSS_VERSION = "TOSS5"
+   endif
 
 else if ( -d /ford1/share/gmao_SIteam/ && -d /ford1/local/ && $arch == Linux ) then
    set site = "GMAO.desktop"
@@ -124,6 +121,7 @@ X86_64:
 set modinit = DUMMY
 
 set loadmodules = 0
+set switchmodules = 0
 set usemodules = 0
 
 #========#
@@ -159,73 +157,47 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   # Due to Intel 2018's age, it does not compile ESMF on TOSS4. Intel 2020 seems to
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-4.0.11/x86_64-unknown-linux-gnu/ifort_2020.4.304-mpt_2.28_25Apr23_rhel87-gcc_8.4.0-TOSS4
-   set mod1 = gcc/8.4
-   set mod2 = comp-intel/2020.4.304
-   set mod3 = mpi-hpe/mpt
-   set mod4 = math-mkl/2020.4.304
-   set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
+   if ( $TOSS_VERSION == "TOSS4" ) then
+      # Due to Intel 2018's age, it does not compile ESMF on TOSS4. Intel 2020 seems to
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-4.0.11/x86_64-unknown-linux-gnu/ifort_2020.4.304-mpt_2.28_25Apr23_rhel87-gcc_8.4.0-TOSS4
+      set mod1 = gcc/8.4
+      set mod2 = comp-intel/2020.4.304
+      set mod3 = mpi-hpe/mpt
+      set mod4 = math-mkl/2020.4.304
+      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
 
-   set mod6 = git/2.40.1
-   set mod7 = cmake/3.28.3
+      set mod6 = git/2.40.1
+      set mod7 = cmake/3.28.3
 
-#  set momdir = /nobackup/gmao_SIteam/ModelData/mom5
+   #  set momdir = /nobackup/gmao_SIteam/ModelData/mom5
 
-   set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 $mod7 )
-   set modinit = /usr/share/modules/init/tcsh
-   set loadmodules = 0
-   set usemodules = 1
+      set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 $mod7 )
+      set modinit = /usr/share/modules/init/tcsh
+      set loadmodules = 0
+      set usemodules = 1
 
-#=========#
-#  JANUS  #
-#=========#
-else if ( $site == GMAO.janus ) then
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/GMAO-Baselibs-4_0_8/x86_64-unknown-linux-gnu/pgfortran_17.5-openmpi_2.1.1
-   set mod1 = comp/pgi/17.5
-   set mod2 = mpi/openmpi/2.1.1/pgi-17.5
-   set mod3 = lib/mkl/17.0.4.196
-   set mod4 = other/python/canopy
-   set mod5 = other/git/latest
+   else
 
-   setenv GPU_CC_REV cc20
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-4.0.11/x86_64-unknown-linux-gnu/ifort_2023.2.1-craympich_8.1.33-TOSS5
 
-#  set momdir = /ford1/share/gmao_SIteam/ModelData/mom5
+      set mod1 = python/GEOSpyD/25.3.1-0/3.13
+      set mod2 = GEOSenv
 
-   set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
-   set modinit = /usr/share/Modules/init/tcsh
-   set loadmodules = 0
-   set usemodules = 1
+      set mod3 = comp-gcc/12.5.0
+      set mod4 = PrgEnv-intel/8.6.0
+      set mod5 = comp-intel/2023.2.1
+      set mod6 = mpi/mpich-ifort-icc
 
-#===========#
-#  Bender   #
-#===========#
-else if ( $site == ACDL.bender ) then
-    set basedir=/ford1/share/gmao_SIteam/Baselibs/GMAO-Baselibs-4_0_6/x86_64-unknown-linux-gnu/ifort_13.1.1.163-openmpi_1.8.1    
-    set BASEBIN=$basedir/$arch/bin
-    set PYBIN = /share/dasilva/epd/epd-7.3-2-rh5-x86_64/bin
-    set IFCBIN = /opt/intel/composer_xe_2013.5.192/bin
-    set MPIBIN = /ford1/share/gmao_SIteam/MPI/openmpi-1.8.1-ifort-13.1.1.163/bin 
-    source $IFCBIN/ifortvars.csh intel64
-    setenv MKLPATH $MKLROOT/lib
-    set path = ( $BASEBIN $MPIBIN $PYBIN $path )
-    set loadmodules = 0
-    set usemodules = 0
+      set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 )
+      set modinit = /opt/cray/pe/modules/3.2.11.7/init/csh
 
-#===========#
-#  Niteroi  #
-#===========#
-else if ( $site == GMAO.niteroi ) then
-    set basedir = /Users/mathomp4/Baselibs/GMAO-Baselibs-4_0_6/x86_64-apple-darwin14.0.0/ifort_15.0.1.108-openmpi_1.8.3
-    set BASEBIN = $basedir/$arch/bin
-    set PYBIN   = /Library/Frameworks/EPD64.framework/Versions/7.3/bin
-    set IFCPATH = /opt/intel/composer_xe_2015.1.108
-    set MPIBIN  = /Users/mathomp4/MPI/openmpi/1.8.3/ifort-15.0.1.108
-    source $IFCPATH/bin/compilervars.csh intel64
-    setenv MKLPATH $MKLROOT/lib
-    set path = ( $BASEBIN $MPIBIN $PYBIN $path )
-    set loadmodules = 0
-    set usemodules = 0
+      set switchmods = ( intel/latest:intel-classic/2023.2.1 )
+      set switchmodules = 1
+
+      set loadmodules = 0
+      set usemodules = 1
+
+   endif
 
 #=================#
 #  GMAO DESKTOP   #
@@ -266,9 +238,6 @@ if ( $#argv > 0 ) then
    if ( $1 == basedir ) then
       echo $basedir
 
-#  else if ( $1 == momdir ) then
-#     echo $momdir
-
    else if ( $1 == modules ) then
       echo $mods
 
@@ -277,6 +246,9 @@ if ( $#argv > 0 ) then
 
    else if ( $1 == loadmodules ) then
       echo $loadmodules
+
+      else if ( $1 == switchmodules ) then
+      echo $switchmods
 
    else if ( $1 == usemodules ) then
       echo $usemodules
@@ -325,19 +297,6 @@ else
    exit 3
 endif
 
-# setenv MOMDIR
-#--------------
-#f ($?momdir) then
-#  if (! $wrapper) echo -n " and MOMDIR"
-#  setenv MOMDIR $momdir
-#lse if ($?MOMDIR) then
-#  if (! $wrapper) echo -n " and MOMDIR found in environment"
-#lse
-#  echo
-#  echo "MOMDIR not found in environment or set by ${scriptname}"
-#  exit 4
-#ndif
-
 # add BASEDIR lib to LD_LIBRARY_PATH, if not already there
 #---------------------------------------------------------
 if ($?LD_LIBRARY_PATH) then
@@ -383,15 +342,27 @@ if (-e $modinit) then
       endif
 
       if ($site == NAS) then
-         module use -a /u/scicon/tools/modulefiles
-         module use -a /nobackup/gmao_SIteam/modulefiles
-         module use -a /nasa/intel/Compiler/2018.1.163
-         module use -a /nasa/modulefiles/testing
+         if ( $TOSS_VERSION == "TOSS4" ) then
+            module use -a /u/scicon/tools/modulefiles
+            module use -a /nobackup/gmao_SIteam/modulefiles
+            module use -a /nasa/intel/Compiler/2018.1.163
+            module use -a /nasa/modulefiles/testing
+         else
+            module use -a /nobackup/gmao_SIteam/modulefiles-TOSS5
+         endif
       endif
 
       if ($site =~ "GMAO.*" ) then
          module use -a /ford1/share/gmao_SIteam/modulefiles
       endif
+   endif
+
+   if ($switchmodules) then
+      foreach switchmod ( $switchmods )
+         set frommodule = `echo $switchmod | cut -d: -f1`
+         set tomodule = `echo $switchmod | cut -d: -f2`
+         module switch $frommodule $tomodule
+      end
    endif
 
    foreach mod ( $mods )
@@ -409,9 +380,6 @@ if ($wrapper) then
    if ($?BASEDIR) then
       echo "export BASEDIR=$BASEDIR"                     >! $outfil
    endif
-#  if ($?MOMDIR) then
-#     echo "export MOMDIR=$MOMDIR"                       >> $outfil
-#  endif
    if ($?LD_LIBRARY_PATH) then
       echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH"     >> $outfil
    endif
@@ -478,7 +446,6 @@ OPTIONS
 
      help                echo usage
      basedir             echo expected value for BASEDIR environment variable
-     momdir              echo expected value for MOMDIR environment variable
      modules             echo expected list of modules
      modinit             echo location of csh module initialization script
      loadmodules         echo logical indicating whether "module load modules"

--- a/src/g5_modules
+++ b/src/g5_modules
@@ -186,8 +186,9 @@ else if ( $site == NAS ) then
       set mod3 = comp-gcc/12.5.0
       set mod4 = PrgEnv-intel/8.6.0
       set mod5 = mpi/mpich-ifort-icc
+      set mod6 = math-mkl/2023.2.1
 
-      set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
+      set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 )
       set modinit = /opt/cray/pe/modules/3.2.11.7/init/csh
 
       set switchmods = ( intel/latest:intel-classic/2023.2.1 )

--- a/src/parallel_build.csh
+++ b/src/parallel_build.csh
@@ -315,6 +315,9 @@ if ( $SITE == NAS ) then
    if ($nT == mil_ait) @ NCPUS_DFLT = 128
    if ($nT == tur_ath) @ NCPUS_DFLT = 256
 
+   # Turin requires at least the normal queue
+   if (($nT == tur_ath) && ("$queue" == "")) set queue = "-q normal"
+
    # TMPDIR needs to be reset
    #-------------------------
    if ($tmpdir == '') then

--- a/src/parallel_build.csh
+++ b/src/parallel_build.csh
@@ -4,6 +4,7 @@
 # purpose: This subroutine builds using pinstall
 #          for compilation parallelization.
 #
+#
 # !REVISION HISTORY
 # 15Mar2007  Stassi  Modified version of g5das_parallel_build.csh
 # 22Mar2007  Kokron  Add support for discover
@@ -26,6 +27,7 @@
 # 10Oct2017  MAT     Added Skylake at NAS. Added option to pass in 
 #                    account
 # 18Feb2022  MAT     Added Rome nodes to NAS
+# 19Mar2026  MAT     Added Turin nodes to NAS
 #------------------------------------------------------------------------
 set name = $0
 set scriptname = $name
@@ -47,9 +49,11 @@ if ( ($node == dirac)   \
    setenv SITE NCCS
 
 else if (($node =~ pfe*)      \
-      || ($node =~ tfe*)      \
+      || ($node =~ afe*)   \
+      || ($node =~ athfe*)   \
       || ($node =~ r[0-9]*i[0-9]*n[0-9]*) \
-      || ($node =~ r[0-9]*c[0-9]*t[0-9]*n[0-9]*)) then
+      || ($node =~ r[0-9]*c[0-9]*t[0-9]*n[0-9]*) \
+      || ($node =~ x[0-9]*c[0-9]*s[0-9]*b[0-9]*n[0-9]*) ) then
    setenv SITE NAS
 
 else
@@ -132,8 +136,9 @@ while ($#argv)
 
    # specify node type
    #------------------
-   if ("$1" == "-rom")  set nodeTYPE = "Rome"
+   if ("$1" == "-tur")  set nodeTYPE = "Turin"
    if ("$1" == "-mil")  set nodeTYPE = "Milan"
+   if ("$1" == "-rom")  set nodeTYPE = "Rome"
    if ("$1" == "-cas")  set nodeTYPE = "CascadeLake"
    if ("$1" == "-sky")  set nodeTYPE = "Skylake"
    if ("$1" == "-bro")  set nodeTYPE = "Broadwell"
@@ -231,7 +236,7 @@ set ntaskspernode = ''
 if ($SITE == NCCS) then
 
    set nT = `echo $nodeTYPE| tr "[A-Z]" "[a-z]" | cut -c1-3 `
-   if (($nT != has) && ($nT != sky) && ($nT != cas) && ($nT != mil) && ($nT != 15c)) then
+   if ( ($nT != cas) && ($nT != mil) ) then
       echo "ERROR. Unknown node type at NCCS: $nodeTYPE"
       exit 1
    endif
@@ -264,27 +269,41 @@ endif
 if ( $SITE == NAS ) then
 
    set nT = `echo $nodeTYPE | cut -c1-3 | tr "[A-Z]" "[a-z]"`
-   if (($nT != has) && ($nT != bro) && ($nT != sky) && ($nT != cas) && ($nT != rom) && ($nT != mil)) then
+   if (($nT != bro) && ($nT != sky) && ($nT != cas) && ($nT != rom) && ($nT != mil) && ($nT != tur)) then
       echo "ERROR. Unknown node type at NAS: $nodeTYPE"
       exit 2
    endif
 
+   # At NAS, you must submit to Milan nodes from afe nodes
+   if ( ($nT == mil) && ($node !~ afe*) ) then
+      echo "ERROR. Milan nodes can only be accessed from afe nodes."
+      exit 2
+   endif
+
+   # At NAS, you must submit to Turin nodes from athfe nodes
+   if ( ($nT == tur) && ($node !~ athfe*) ) then
+      echo "ERROR. Turin nodes can only be accessed from athfe nodes."
+      exit 2
+   endif
+
+   if ($nT == tur) set nT = 'tur_ath'
    if ($nT == mil) set nT = 'mil_ait'
    if ($nT == rom) set nT = 'rom_ait'
-   if ($nT == sky) set nT = 'sky_ele'
    if ($nT == cas) set nT = 'cas_ait'
+   if ($nT == sky) set nT = 'sky_ele'
+   if ($nT == bro) set nT = 'bro_ele'
    set proc = ":model=$nT"
 
-   if ($nT == has)     @ NCPUS_DFLT = 24
-   if ($nT == bro)     @ NCPUS_DFLT = 28
+   if ($nT == bro_ele) @ NCPUS_DFLT = 28
    if ($nT == sky_ele) @ NCPUS_DFLT = 40
    if ($nT == cas_ait) @ NCPUS_DFLT = 40
    if ($nT == rom_ait) @ NCPUS_DFLT = 128
    if ($nT == mil_ait) @ NCPUS_DFLT = 128
+   if ($nT == tur_ath) @ NCPUS_DFLT = 256
 
    # TMPDIR needs to be reset
    #-------------------------
-   if (! "$tmpdir") then
+   if ($tmpdir == '') then
       set tmpdirDFLT = "/nobackup/$USER/scratch/"
       if ($prompt) then
          echo ""
@@ -293,6 +312,8 @@ if ( $SITE == NAS ) then
          echo -n "TMPDIR [$tmpdirDFLT] "
          setenv tmpdir $<
          if ("$tmpdir" == "") setenv tmpdir $tmpdirDFLT
+      else
+         setenv tmpdir $tmpdirDFLT
       endif
    endif
    echo "TMPDIR: $tmpdir"
@@ -775,10 +796,10 @@ flagged options
    -tmpdir dir         alternate Fortran TMPDIR location
    -walltime hh:mm:ss  time to use as batch walltime at job submittal
 
-   -rom                 compile on Rome nodes (only at NAS)
-   -mil                 compile on Milan nodes
+   -tur                 compile on Turin nodes (only at NAS, must be submitted from athfe nodes)
+   -mil                 compile on Milan nodes (default at NCCS; at NAS must be submitted from afe nodes)
+   -rom                 compile on Rome nodes (default at NAS, only at NAS)
    -cas                 compile on Cascade Lake nodes
    -sky                 compile on Skylake nodes (only at NAS)
    -bro                 compile on Broadwell nodes (only at NAS)
-   -has                 compile on Haswell nodes (only at NAS)
 EOF

--- a/src/parallel_build.csh
+++ b/src/parallel_build.csh
@@ -28,6 +28,8 @@
 #                    account
 # 18Feb2022  MAT     Added Rome nodes to NAS
 # 19Mar2026  MAT     Added Turin nodes to NAS
+# 25Mar2026  MAT     Default NAS node type now based on login node
+#                    (pfe->Rome, afe->Milan, athfe->Turin)
 #------------------------------------------------------------------------
 set name = $0
 set scriptname = $name
@@ -225,7 +227,19 @@ end
 #-----------------
 if (! $?nodeTYPE) then
    if ($SITE == NCCS) set nodeTYPE = "Milan"
-   if ($SITE == NAS)  set nodeTYPE = "Rome"
+   if ($SITE == NAS) then
+      # Default node type depends on which NAS login node we are on:
+      #   pfe*   --> Rome  (rom_ait)
+      #   afe*   --> Milan (mil_ait)
+      #   athfe* --> Turin (tur_ath)
+      if ($node =~ athfe*) then
+         set nodeTYPE = "Turin"
+      else if ($node =~ afe*) then
+         set nodeTYPE = "Milan"
+      else
+         set nodeTYPE = "Rome"
+      endif
+   endif
 endif
 
 # This is a flag needed at NCCS for Cascade Lake. Default is blank
@@ -798,8 +812,13 @@ flagged options
 
    -tur                 compile on Turin nodes (only at NAS, must be submitted from athfe nodes)
    -mil                 compile on Milan nodes (default at NCCS; at NAS must be submitted from afe nodes)
-   -rom                 compile on Rome nodes (default at NAS, only at NAS)
+   -rom                 compile on Rome nodes (only at NAS)
    -cas                 compile on Cascade Lake nodes
    -sky                 compile on Skylake nodes (only at NAS)
    -bro                 compile on Broadwell nodes (only at NAS)
+
+   Default NAS node type is based on login node:
+      pfe*   -> Rome  (-rom)
+      afe*   -> Milan (-mil)
+      athfe* -> Turin (-tur)
 EOF


### PR DESCRIPTION
This PR is an attempt to collect the changes needed to run S2S on Athena at NAS.

## Current Status

I was able to run a c180 1440x1080 job on Athena with these changes. Some stats:


| Run      | Wall Time | Nodes | SBU Rate | Cores Per Node | Approx SBUs |
|----------|-----------|-------|----------|----------------|-------------|
| Rome     | 15:53     | 18    | 4.06     | 120            | 20          |
| Rome HT  | 26:23     | 9     | 4.06     | 240            | 16          |
| Turin    | 12:53     | 9     | 12.20    | 240            | 24          |
| Turin HT | 13:53     | 5     | 12.20    | 480            | 14          |

S2S does seem to not hate using hyperthreading on the Turins. 

It does run with hyperthreading on the Romes but was slower. It seems almost too slow, so I'm re-running 

## Build Updates

The main changes are a new Baselibs build as well as updates to the Make system. One to support MPICH and the other because of a `pinstall` issue.

## Scripting changes

Well, I did try to update `parallel_build.csh` to work. I think it should work once I get the manual build working but...not sure. 

NOTE: At NAS, I now try to have "sensible" defaults for `parallel_build.csh`. If you submit on `pfe`, you get `rom_ait`; on `afe`, `mil_ait`; and on `athfe`, `tur_ath`.

I also put in a bit of a hack in `gcm_setup` so that if you run that from Athena (or I guess TOSS5) you get a Turin job out.

What will be needed more is help from @qvis for all the scripting around the build to know about Turin. A simple example is `gcm_setup` but then we have all the things that ask "am I at NAS".

For Athena, that means you don't look for `pfe` but for `athfe` and compute nodes have hostnames like:
```
($node =~ x[0-9]*c[0-9]*s[0-9]*b[0-9]*n[0-9]*) ) then
```