### PR TITLE
Bugfix/plotting bugfix and listing consistency

### DIFF
--- a/src/Applications/GEOSgcm_App/gcm_run.j
+++ b/src/Applications/GEOSgcm_App/gcm_run.j
@@ -1000,7 +1000,6 @@ endif
 >>>withODAS<<< set RUN_STATUS = 'out'
 >>>withODAS<<< @BATCH_CHANGE_JOBNAME
 >>>withODAS<<< @BATCH_CHANGE_OUTPUTNAME
->>>withODAS<<< exit
 
 if ( $rc == 0 ) then
       cd  $HOMDIR

--- a/src/Applications/GEOSgcm_App/gcm_run.j
+++ b/src/Applications/GEOSgcm_App/gcm_run.j
@@ -996,6 +996,7 @@ endif
 >>>withODAS<<< echo "Running plot_V3_rt.csh"
 >>>withODAS<<< setenv ODAS_MAILLIST "kazumi.nakada@nasa.gov,andrea.m.molod@nasa.gov,veronica.i.ruizxomchuk@nasa.gov"
 >>>withODAS<<< $GEOSUTIL/plots/odas_plots/plot_V3_rt.csh
+>>>withODAS<<< wait
 >>>withODAS<<< set RUN_STATUS = 'out'
 >>>withODAS<<< @BATCH_CHANGE_JOBNAME
 >>>withODAS<<< @BATCH_CHANGE_OUTPUTNAME

--- a/src/Applications/GEOSgcm_App/gcm_run.j
+++ b/src/Applications/GEOSgcm_App/gcm_run.j
@@ -996,7 +996,7 @@ endif
 >>>withODAS<<< echo "Running plot_V3_rt.csh"
 >>>withODAS<<< setenv ODAS_MAILLIST "kazumi.nakada@nasa.gov,andrea.m.molod@nasa.gov,veronica.i.ruizxomchuk@nasa.gov"
 >>>withODAS<<< $GEOSUTIL/plots/odas_plots/plot_V3_rt.csh
->>>withODAS<<< set RUN_STATUS = 'DONE'
+>>>withODAS<<< set RUN_STATUS = 'out'
 >>>withODAS<<< @BATCH_CHANGE_JOBNAME
 >>>withODAS<<< @BATCH_CHANGE_OUTPUTNAME
 >>>withODAS<<< exit

--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -1378,7 +1378,7 @@ if( $SITE == 'NAS' ) then
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
               setenv BATCH_CHANGE_JOBNAME ''
-              setenv BATCH_CHANGE_OUTPUTNAME 'qalter -o ${EXPDIR}/${EXPID}.${qdate}.${PBS_JOBID}.${RUN_STATUS} ${PBS_JOBID}'
+              setenv BATCH_CHANGE_OUTPUTNAME 'qalter -o ${EXPDIR}/${EXPID}.${firstdate}.${PBS_JOBID}.${RUN_STATUS} ${PBS_JOBID}'
               setenv BATCH_OUTPUTNAME_AMENDMENT ""
               setenv BATCH_JOINOUTERR "PBS -j oe -k oed"    # PBS Syntax for joining output and error
               setenv     RUN_FT "6:00:00"                                              # Wallclock Time   for gcm_forecast.j
@@ -1439,7 +1439,7 @@ else if( $SITE == 'NCCS' ) then
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_CHANGE_JOBNAME 'scontrol update JobId=${SLURM_JOB_ID} JobName=${EXPID}.${RUN_STATUS}'
-              setenv BATCH_CHANGE_OUTPUTNAME 'scontrol update JobId=${SLURM_JOB_ID} comment="stdout=${EXPDIR}/${EXPID}.${qdate}.${SLURM_JOB_ID}.${RUN_STATUS}"'
+              setenv BATCH_CHANGE_OUTPUTNAME 'scontrol update JobId=${SLURM_JOB_ID} comment="stdout=${EXPDIR}/${EXPID}.${firstdate}.${SLURM_JOB_ID}.${RUN_STATUS}"'
               setenv BATCH_OUTPUTNAME_AMENDMENT ""
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
               setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j

--- a/src/GMAO_Shared/GEOS_Util/plots/odas_plots/plot_V3_rt.csh
+++ b/src/GMAO_Shared/GEOS_Util/plots/odas_plots/plot_V3_rt.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -v
+#!/bin/csh -vf
 
 #module load other/ImageMagick/latest
 #module load ncview/2.1.7


### PR DESCRIPTION
The most recent run this weekend showed some differences between the previous listings and the current ones that are cosmetically inconsistent with the previous runs. 

the previous runs used the cap_restart date as the date that was attached to the listing. This new one used 'qdate' which was just 4 days ahead of the cap_restart date, at the end of the pentad. For consistency's sake it is best to leave this indicator as it previously was. 

the previous run used 'out' as the suffix for a successful listing. the new one uses 'DONE'. in the name of consistency we should change back. 