### PR TITLE
Bugfix/date standardization and csh options

### DIFF
--- a/src/Applications/GEOSgcm_App/gcm_run.j
+++ b/src/Applications/GEOSgcm_App/gcm_run.j
@@ -717,8 +717,8 @@ if ( -x $GEOSBIN/rs_numtiles.x ) then
    if ( $N_SALT_TILES_EXPECTED != $N_SALT_TILES_FOUND ) then
       echo "Error! Found $N_SALT_TILES_FOUND tiles in saltwater. Expect to find $N_SALT_TILES_EXPECTED tiles."
       echo "Your restarts are probably for a different ocean."
-      mkdir -p $EXPDIR/morgue/${init_date}
-      mv $SCRDIR $EXPDIR/morgue/${init_date}
+      mkdir -p $EXPDIR/morgue/${firstdate}
+      mv $SCRDIR $EXPDIR/morgue/${firstdate}
       exit 7
    endif    
 
@@ -772,8 +772,8 @@ if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh
 >>>withODAS<<<   set RUN_STATUS = 'ODAS_FAILED'
 >>>withODAS<<<   @BATCH_CHANGE_JOBNAME
 >>>withODAS<<<   @BATCH_CHANGE_OUTPUTNAME
->>>withODAS<<<   mkdir -p $EXPDIR/morgue/${init_date}
->>>withODAS<<<   mv $SCRDIR $EXPDIR/morgue/${init_date}
+>>>withODAS<<<   mkdir -p $EXPDIR/morgue/${firstdate}
+>>>withODAS<<<   mv $SCRDIR $EXPDIR/morgue/${firstdate}
 >>>withODAS<<<   exit(1)
 >>>withODAS<<<endif
 >>>withODAS<<<

--- a/src/Applications/GEOSgcm_App/gcm_run.j
+++ b/src/Applications/GEOSgcm_App/gcm_run.j
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/bin/csh -fx
 
 #######################################################################
 #                     Batch Parameters for Run Job
@@ -55,8 +55,6 @@ setenv  GCMEMIP @GCMEMIP
 set year  = `echo $firstdate | cut -d_ -f1 | cut -b1-4`
 set month = `echo $firstdate | cut -d_ -f1 | cut -b5-6`
 set init_date = `echo $firstdate | cut -d_ -f1 | cut -b1-8`
-
-set qdate = `${GEOSBIN}/tick ${init_date} 000000 4 0 | cut -c1-8`
 set RUN_STATUS = 'BEGINNING'
 @BATCH_CHANGE_JOBNAME
 
@@ -719,8 +717,8 @@ if ( -x $GEOSBIN/rs_numtiles.x ) then
    if ( $N_SALT_TILES_EXPECTED != $N_SALT_TILES_FOUND ) then
       echo "Error! Found $N_SALT_TILES_FOUND tiles in saltwater. Expect to find $N_SALT_TILES_EXPECTED tiles."
       echo "Your restarts are probably for a different ocean."
-      mkdir -p $EXPDIR/morgue/${qdate}
-      mv $SCRDIR $EXPDIR/morgue/${qdate}
+      mkdir -p $EXPDIR/morgue/${init_date}
+      mv $SCRDIR $EXPDIR/morgue/${init_date}
       exit 7
    endif    
 
@@ -774,8 +772,8 @@ if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh
 >>>withODAS<<<   set RUN_STATUS = 'ODAS_FAILED'
 >>>withODAS<<<   @BATCH_CHANGE_JOBNAME
 >>>withODAS<<<   @BATCH_CHANGE_OUTPUTNAME
->>>withODAS<<<   mkdir -p $EXPDIR/morgue/${qdate}
->>>withODAS<<<   mv $SCRDIR $EXPDIR/morgue/${qdate}
+>>>withODAS<<<   mkdir -p $EXPDIR/morgue/${init_date}
+>>>withODAS<<<   mv $SCRDIR $EXPDIR/morgue/${init_date}
 >>>withODAS<<<   exit(1)
 >>>withODAS<<<endif
 >>>withODAS<<<

--- a/src/Applications/GEOSgcm_App/gcm_run.j
+++ b/src/Applications/GEOSgcm_App/gcm_run.j
@@ -994,7 +994,7 @@ endif
 >>>withODAS<<< echo "Running plot_V3_rt.csh"
 >>>withODAS<<< setenv ODAS_MAILLIST "kazumi.nakada@nasa.gov,andrea.m.molod@nasa.gov,veronica.i.ruizxomchuk@nasa.gov"
 >>>withODAS<<< $GEOSUTIL/plots/odas_plots/plot_V3_rt.csh
->>>withODAS<<< set RUN_STATUS = 'DONE'
+>>>withODAS<<< set RUN_STATUS = 'out'
 >>>withODAS<<< @BATCH_CHANGE_JOBNAME
 >>>withODAS<<< @BATCH_CHANGE_OUTPUTNAME
 >>>withODAS<<< exit

--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -1378,7 +1378,7 @@ if( $SITE == 'NAS' ) then
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
               setenv BATCH_CHANGE_JOBNAME ''
-              setenv BATCH_CHANGE_OUTPUTNAME 'qalter -o ${EXPDIR}/${EXPID}.${init_date}.${PBS_JOBID}.${RUN_STATUS} ${PBS_JOBID}'
+              setenv BATCH_CHANGE_OUTPUTNAME 'qalter -o ${EXPDIR}/${EXPID}.${firstdate}.${PBS_JOBID}.${RUN_STATUS} ${PBS_JOBID}'
               setenv BATCH_OUTPUTNAME_AMENDMENT ""
               setenv BATCH_JOINOUTERR "PBS -j oe -k oed"    # PBS Syntax for joining output and error
               setenv     RUN_FT "6:00:00"                                              # Wallclock Time   for gcm_forecast.j
@@ -1439,7 +1439,7 @@ else if( $SITE == 'NCCS' ) then
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_CHANGE_JOBNAME 'scontrol update JobId=${SLURM_JOB_ID} JobName=${EXPID}.${RUN_STATUS}'
-              setenv BATCH_CHANGE_OUTPUTNAME 'scontrol update JobId=${SLURM_JOB_ID} comment="stdout=${EXPDIR}/${EXPID}.${init_date}.${SLURM_JOB_ID}.${RUN_STATUS}"'
+              setenv BATCH_CHANGE_OUTPUTNAME 'scontrol update JobId=${SLURM_JOB_ID} comment="stdout=${EXPDIR}/${EXPID}.${firstdate}.${SLURM_JOB_ID}.${RUN_STATUS}"'
               setenv BATCH_OUTPUTNAME_AMENDMENT ""
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
               setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j

--- a/src/Applications/GEOSgcm_App/gcm_setup
+++ b/src/Applications/GEOSgcm_App/gcm_setup
@@ -1378,7 +1378,7 @@ if( $SITE == 'NAS' ) then
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
               setenv BATCH_CHANGE_JOBNAME ''
-              setenv BATCH_CHANGE_OUTPUTNAME 'qalter -o ${EXPDIR}/${EXPID}.${qdate}.${PBS_JOBID}.${RUN_STATUS} ${PBS_JOBID}'
+              setenv BATCH_CHANGE_OUTPUTNAME 'qalter -o ${EXPDIR}/${EXPID}.${init_date}.${PBS_JOBID}.${RUN_STATUS} ${PBS_JOBID}'
               setenv BATCH_OUTPUTNAME_AMENDMENT ""
               setenv BATCH_JOINOUTERR "PBS -j oe -k oed"    # PBS Syntax for joining output and error
               setenv     RUN_FT "6:00:00"                                              # Wallclock Time   for gcm_forecast.j
@@ -1439,7 +1439,7 @@ else if( $SITE == 'NCCS' ) then
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_CHANGE_JOBNAME 'scontrol update JobId=${SLURM_JOB_ID} JobName=${EXPID}.${RUN_STATUS}'
-              setenv BATCH_CHANGE_OUTPUTNAME 'scontrol update JobId=${SLURM_JOB_ID} comment="stdout=${EXPDIR}/${EXPID}.${qdate}.${SLURM_JOB_ID}.${RUN_STATUS}"'
+              setenv BATCH_CHANGE_OUTPUTNAME 'scontrol update JobId=${SLURM_JOB_ID} comment="stdout=${EXPDIR}/${EXPID}.${init_date}.${SLURM_JOB_ID}.${RUN_STATUS}"'
               setenv BATCH_OUTPUTNAME_AMENDMENT ""
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
               setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j

--- a/src/GMAO_Shared/GEOS_Util/plots/odas_plots/plot_V3_rt.csh
+++ b/src/GMAO_Shared/GEOS_Util/plots/odas_plots/plot_V3_rt.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -v
+#!/bin/csh -vf
 
 #module load other/ImageMagick/latest
 #module load ncview/2.1.7


### PR DESCRIPTION
Probably a few more commits than needed but didn't want to make another branch once I seen my error. 

That error being swapping qdate (cap_restart +4) with init_date (cap_restart with hourly component).

What I really wanted was to swap qdate with firstdate (cap_restart with just year/month/day component)

Last additions were a -x flag to gcm_run.j to print out the lines being executed and a -f flag in plot_V3_rt.csh to ensure the use of the intended GEOSUTIL environment variable.